### PR TITLE
fix: Sentry 테스트 이벤트 수집 흐름 개선

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -17,10 +17,12 @@ export function middleware(req: NextRequest, ev: NextFetchEvent) {
   }
   const isToolPath = pathname === "/tool" || pathname.startsWith("/tool/");
   const isToolLoginLoadingPath = pathname === "/login-loading";
+  const isSentryTestPath =
+    pathname === "/sentry-example-page" || pathname.startsWith("/sentry-example-page/");
   const hasToolMode = req.cookies.get(TOOL_MODE_COOKIE)?.value === "1";
   let response: NextResponse | null = null;
 
-  if (hasToolMode && !isToolPath && !isToolLoginLoadingPath) {
+  if (hasToolMode && !isToolPath && !isToolLoginLoadingPath && !isSentryTestPath) {
     if (pathname === "/auth/login") {
       const toolLoginUrl = new URL("/tool/login", req.url);
       const next = req.nextUrl.searchParams.get("next");


### PR DESCRIPTION
## 목적
- Sentry 온보딩 테스트 시 이벤트가 안 들어오는 문제를 해결합니다.

## 변경 사항
- tool 모드 쿠키가 있어도 `/sentry-example-page` 접근을 허용하도록 미들웨어 예외 처리 추가
- 실제 서비스 로직에는 영향 없이 Sentry 테스트 동선만 개선

## 검증
- `npm run verify:ci` 통과
- 이후 `/sentry-example-page`에서 테스트 에러 트리거 가능
