### PR TITLE
style: 경매 다크모드 UI 가독성 개선

### DIFF
--- a/app/(web)/auctions/AuctionsClient.tsx
+++ b/app/(web)/auctions/AuctionsClient.tsx
@@ -103,17 +103,17 @@ export default function AuctionsClient() {
     <Layout icon hasTabBar seoTitle="경매" showSearch>
       <div className="flex flex-col h-full">
         <div className="px-4 pt-3 pb-2">
-          <div className="overflow-hidden rounded-2xl border border-slate-200 bg-white">
+          <div className="overflow-hidden rounded-2xl border border-slate-200 bg-white dark:border-slate-700 dark:bg-slate-900">
             <div className="px-4 py-4">
               <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
                 <div>
-                  <p className="text-[11px] font-semibold uppercase tracking-[0.12em] text-slate-500">
+                  <p className="text-[11px] font-semibold uppercase tracking-[0.12em] text-slate-500 dark:text-slate-400">
                     Bredy Auction
                   </p>
-                  <h1 className="mt-1 text-xl font-black tracking-[-0.02em] text-slate-900">
+                  <h1 className="mt-1 text-xl font-black tracking-[-0.02em] text-slate-900 dark:text-slate-50">
                     카페/밴드 링크형 경매
                   </h1>
-                  <p className="mt-1.5 text-xs leading-relaxed text-slate-600">
+                  <p className="mt-1.5 text-xs leading-relaxed text-slate-600 dark:text-slate-300">
                     카카오 로그인 기반 참여, 자동 연장, 입찰 검증으로
                     경매 운영 리스크를 줄였습니다.
                   </p>
@@ -127,13 +127,13 @@ export default function AuctionsClient() {
                   </Link>
                   <Link
                     href="/auction-tool"
-                    className="inline-flex h-8 items-center rounded-full bg-slate-900 px-3 text-[11px] font-semibold text-white transition-colors hover:bg-slate-800"
+                    className="inline-flex h-8 items-center rounded-full bg-slate-900 px-3 text-[11px] font-semibold text-white transition-colors hover:bg-slate-800 dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-slate-200"
                   >
                     도구 소개
                   </Link>
                   <Link
                     href="/auctions/rules"
-                    className="inline-flex h-8 items-center rounded-full border border-slate-300 bg-white px-3 text-[11px] font-semibold text-slate-700 transition-colors hover:bg-slate-50"
+                    className="inline-flex h-8 items-center rounded-full border border-slate-300 bg-white px-3 text-[11px] font-semibold text-slate-700 transition-colors hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700"
                   >
                     운영 룰
                   </Link>
@@ -141,17 +141,17 @@ export default function AuctionsClient() {
               </div>
 
               <div className="mt-3 grid grid-cols-1 gap-2 sm:grid-cols-3">
-                <article className="rounded-lg border border-slate-200 bg-slate-50 px-3 py-2.5">
-                  <p className="text-[10px] font-semibold text-slate-500">입찰 검증</p>
-                  <p className="mt-0.5 text-[12px] font-bold text-slate-800">호가 단위 자동 검증</p>
+                <article className="rounded-lg border border-slate-200 bg-slate-50 px-3 py-2.5 dark:border-slate-700 dark:bg-slate-800">
+                  <p className="text-[10px] font-semibold text-slate-500 dark:text-slate-400">입찰 검증</p>
+                  <p className="mt-0.5 text-[12px] font-bold text-slate-800 dark:text-slate-100">호가 단위 자동 검증</p>
                 </article>
-                <article className="rounded-lg border border-slate-200 bg-slate-50 px-3 py-2.5">
-                  <p className="text-[10px] font-semibold text-slate-500">마감 정책</p>
-                  <p className="mt-0.5 text-[12px] font-bold text-slate-800">마감 임박 시 자동 연장</p>
+                <article className="rounded-lg border border-slate-200 bg-slate-50 px-3 py-2.5 dark:border-slate-700 dark:bg-slate-800">
+                  <p className="text-[10px] font-semibold text-slate-500 dark:text-slate-400">마감 정책</p>
+                  <p className="mt-0.5 text-[12px] font-bold text-slate-800 dark:text-slate-100">마감 임박 시 자동 연장</p>
                 </article>
-                <article className="rounded-lg border border-slate-200 bg-slate-50 px-3 py-2.5">
-                  <p className="text-[10px] font-semibold text-slate-500">운영 정책</p>
-                  <p className="mt-0.5 text-[12px] font-bold text-slate-800">신고/위반 계정 참여 제한</p>
+                <article className="rounded-lg border border-slate-200 bg-slate-50 px-3 py-2.5 dark:border-slate-700 dark:bg-slate-800">
+                  <p className="text-[10px] font-semibold text-slate-500 dark:text-slate-400">운영 정책</p>
+                  <p className="mt-0.5 text-[12px] font-bold text-slate-800 dark:text-slate-100">신고/위반 계정 참여 제한</p>
                 </article>
               </div>
 
@@ -160,7 +160,7 @@ export default function AuctionsClient() {
                   value={searchInput}
                   onChange={(event) => setSearchInput(event.target.value)}
                   placeholder="경매 매물 검색 (제목/설명/판매자)"
-                  className="h-9 w-full rounded-lg border border-slate-200 bg-white px-3 text-sm outline-none transition focus:border-slate-400"
+                  className="h-9 w-full rounded-lg border border-slate-200 bg-white px-3 text-sm text-slate-900 outline-none transition placeholder:text-slate-400 focus:border-slate-400 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100 dark:placeholder:text-slate-500 dark:focus:border-slate-500"
                 />
                 <button
                   type="submit"
@@ -172,7 +172,7 @@ export default function AuctionsClient() {
                   <button
                     type="button"
                     onClick={handleSearchReset}
-                    className="inline-flex h-9 shrink-0 items-center rounded-lg border border-slate-200 bg-white px-2.5 text-xs font-medium text-slate-600 transition-colors hover:bg-slate-50"
+                    className="inline-flex h-9 shrink-0 items-center rounded-lg border border-slate-200 bg-white px-2.5 text-xs font-medium text-slate-600 transition-colors hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700"
                   >
                     초기화
                   </button>
@@ -183,7 +183,7 @@ export default function AuctionsClient() {
         </div>
 
         {/* 상태 탭 */}
-        <div className="sticky top-14 z-10 bg-white/80 backdrop-blur-sm border-b border-gray-100">
+        <div className="sticky top-14 z-10 border-b border-gray-100 bg-white/80 backdrop-blur-sm dark:border-slate-800 dark:bg-slate-900/85">
           <div className="flex overflow-x-auto scrollbar-hide px-4 pt-3 gap-2">
             {CATEGORY_TABS.map((tab) => (
               <button
@@ -192,8 +192,8 @@ export default function AuctionsClient() {
                 className={cn(
                   "flex-shrink-0 px-3 py-1.5 rounded-full text-xs font-medium transition-colors whitespace-nowrap",
                   selectedCategory === tab.id
-                    ? "bg-slate-200 text-slate-900"
-                    : "bg-slate-100 text-slate-600 hover:bg-slate-200"
+                    ? "bg-slate-200 text-slate-900 dark:bg-slate-100 dark:text-slate-900"
+                    : "bg-slate-100 text-slate-600 hover:bg-slate-200 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700"
                 )}
               >
                 {tab.name}
@@ -208,8 +208,8 @@ export default function AuctionsClient() {
                 className={cn(
                   "flex-shrink-0 px-4 py-2 rounded-full text-sm font-medium transition-colors whitespace-nowrap",
                   selectedStatus === tab.id
-                    ? "bg-gray-900 text-white"
-                    : "bg-gray-100 text-gray-600 hover:bg-gray-200"
+                    ? "bg-gray-900 text-white dark:bg-slate-100 dark:text-slate-900"
+                    : "bg-gray-100 text-gray-600 hover:bg-gray-200 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700"
                 )}
               >
                 {tab.name}
@@ -227,7 +227,7 @@ export default function AuctionsClient() {
                   <Link
                     key={auction.id}
                     href={`/auctions/${auction.id}`}
-                    className="block overflow-hidden rounded-xl border border-slate-100 bg-white"
+                    className="block overflow-hidden rounded-xl border border-slate-100 bg-white dark:border-slate-800 dark:bg-slate-900"
                   >
                     {/* 이미지 */}
                     <div className="relative aspect-[4/3]">
@@ -240,7 +240,7 @@ export default function AuctionsClient() {
                           sizes="(max-width: 640px) 50vw, 280px"
                         />
                       ) : (
-                        <div className="w-full h-full bg-gray-100" />
+                        <div className="h-full w-full bg-gray-100 dark:bg-slate-800" />
                       )}
                       {/* 상태 뱃지 */}
                       <div className="absolute top-2 left-2">
@@ -273,18 +273,18 @@ export default function AuctionsClient() {
                           </span>
                         )}
                       </div>
-                      <h3 className="text-sm font-semibold text-gray-900 line-clamp-1">
+                      <h3 className="line-clamp-1 text-sm font-semibold text-gray-900 dark:text-slate-100">
                         {auction.title}
                       </h3>
                       <div className="mt-2 flex items-end justify-between gap-2">
                         <div className="min-w-0">
-                          <p className="text-[10px] text-gray-400">현재가</p>
+                          <p className="text-[10px] text-gray-400 dark:text-slate-500">현재가</p>
                           <p className="text-sm font-bold text-primary line-clamp-1">
                             {auction.currentPrice.toLocaleString()}원
                           </p>
                         </div>
                         <div className="text-right">
-                          <p className="text-[10px] text-gray-400">
+                          <p className="text-[10px] text-gray-400 dark:text-slate-500">
                             입찰 {auction._count.bids}회
                           </p>
                           <div className="flex items-center justify-end gap-1 mt-1">
@@ -297,9 +297,9 @@ export default function AuctionsClient() {
                                 alt=""
                               />
                             ) : (
-                              <div className="w-4 h-4 rounded-full bg-gray-200" />
+                              <div className="h-4 w-4 rounded-full bg-gray-200 dark:bg-slate-700" />
                             )}
-                            <span className="max-w-[56px] truncate text-[10px] text-gray-500">
+                            <span className="max-w-[56px] truncate text-[10px] text-gray-500 dark:text-slate-400">
                               {auction.user?.name}
                             </span>
                           </div>
@@ -313,11 +313,11 @@ export default function AuctionsClient() {
           ) : (
             <div className="grid grid-cols-2 gap-3">
               {[...Array(4)].map((_, i) => (
-                <div key={i} className="overflow-hidden rounded-xl border border-slate-100 bg-white animate-pulse">
-                  <div className="aspect-[4/3] bg-gray-200" />
-                  <div className="p-2.5 space-y-2">
-                    <div className="h-3 bg-gray-200 rounded w-3/4" />
-                    <div className="h-4 bg-gray-200 rounded w-1/2" />
+                <div key={i} className="animate-pulse overflow-hidden rounded-xl border border-slate-100 bg-white dark:border-slate-800 dark:bg-slate-900">
+                  <div className="aspect-[4/3] bg-gray-200 dark:bg-slate-800" />
+                  <div className="space-y-2 p-2.5">
+                    <div className="h-3 w-3/4 rounded bg-gray-200 dark:bg-slate-700" />
+                    <div className="h-4 w-1/2 rounded bg-gray-200 dark:bg-slate-700" />
                   </div>
                 </div>
               ))}
@@ -326,7 +326,7 @@ export default function AuctionsClient() {
 
           {/* 빈 상태 */}
           {data && data.length > 0 && data[0].auctions.length === 0 && (
-            <div className="flex flex-col items-center justify-center py-20 text-gray-400">
+            <div className="flex flex-col items-center justify-center py-20 text-gray-400 dark:text-slate-500">
               <p className="text-lg font-medium">조건에 맞는 경매가 없습니다</p>
               <p className="text-sm mt-1">첫 경매를 등록해 보세요!</p>
             </div>

--- a/app/(web)/auctions/[id]/AuctionDetailClient.tsx
+++ b/app/(web)/auctions/[id]/AuctionDetailClient.tsx
@@ -402,7 +402,7 @@ const AuctionDetailClient = () => {
         )}
       >
         {/* 이미지 슬라이더 */}
-        <div className="relative aspect-[4/3] bg-gray-100">
+        <div className="relative aspect-[4/3] bg-gray-100 dark:bg-slate-800">
           <Image
             src={mainImageSrc}
             fallbackSrc={DETAIL_FALLBACK_IMAGE}
@@ -434,8 +434,8 @@ const AuctionDetailClient = () => {
             className={cn(
               "mt-4 py-3 px-4 rounded-xl text-center font-bold",
               countdown.isEnded || auction.status !== "진행중"
-                ? "bg-gray-100 text-gray-500"
-                : "bg-red-50 text-red-600"
+                ? "bg-gray-100 text-gray-500 dark:bg-slate-800 dark:text-slate-300"
+                : "bg-red-50 text-red-600 dark:bg-rose-950/40 dark:text-rose-300"
             )}
           >
             {auction.status === "진행중" ? (
@@ -455,9 +455,9 @@ const AuctionDetailClient = () => {
           </div>
 
           {auction.status === "취소" && (
-            <div className="mt-3 rounded-xl border border-rose-200 bg-rose-50 px-3.5 py-3">
-              <p className="text-sm font-bold text-rose-800">신고/운영 처리로 경매 중단</p>
-              <p className="mt-1 text-xs leading-relaxed text-rose-900">
+            <div className="mt-3 rounded-xl border border-rose-200 bg-rose-50 px-3.5 py-3 dark:border-rose-800 dark:bg-rose-950/40">
+              <p className="text-sm font-bold text-rose-800 dark:text-rose-200">신고/운영 처리로 경매 중단</p>
+              <p className="mt-1 text-xs leading-relaxed text-rose-900 dark:text-rose-200/90">
                 이 경매는 운영 정책에 따라 취소되었습니다. 추가 이의가 있으면 신고 접수 채널로 문의해 주세요.
               </p>
             </div>
@@ -468,24 +468,24 @@ const AuctionDetailClient = () => {
               className={cn(
                 "mt-3 rounded-xl border px-3.5 py-3",
                 isWinner
-                  ? "border-emerald-200 bg-emerald-50"
-                  : "border-blue-200 bg-blue-50"
+                  ? "border-emerald-200 bg-emerald-50 dark:border-emerald-800 dark:bg-emerald-950/35"
+                  : "border-blue-200 bg-blue-50 dark:border-blue-800 dark:bg-blue-950/35"
               )}
             >
               <p
                 className={cn(
                   "text-sm font-bold",
-                  isWinner ? "text-emerald-800" : "text-blue-800"
+                  isWinner ? "text-emerald-800 dark:text-emerald-200" : "text-blue-800 dark:text-blue-200"
                 )}
               >
                 {isWinner ? "낙찰 완료: 축하합니다!" : "낙찰 결과"}
               </p>
-              <div className="mt-1.5 space-y-1 text-xs text-slate-700">
+              <div className="mt-1.5 space-y-1 text-xs text-slate-700 dark:text-slate-200">
                 <p>낙찰자: {winnerBid.user?.name}</p>
                 <p>낙찰가: {winnerBid.amount.toLocaleString()}원</p>
                 <p>종료시각: {new Date(auction.endAt).toLocaleString()}</p>
               </div>
-              <div className="mt-2 rounded-lg border border-white/80 bg-white/80 px-2.5 py-2 text-[11px] text-slate-700">
+              <div className="mt-2 rounded-lg border border-white/80 bg-white/80 px-2.5 py-2 text-[11px] text-slate-700 dark:border-slate-700 dark:bg-slate-800/80 dark:text-slate-200">
                 {isWinner ? (
                   <p>
                     판매자 신뢰 정보(전화/이메일/블로그)를 확인해 거래를 진행하세요. 분쟁 발생 시 신고 기능을 사용하세요.
@@ -505,7 +505,7 @@ const AuctionDetailClient = () => {
 
           {/* 판매자 정보 */}
           {isToolRoute ? (
-            <div className="flex items-center gap-3 py-4 border-b border-gray-100">
+            <div className="flex items-center gap-3 border-b border-gray-100 py-4 dark:border-slate-800">
               {auction.user?.avatar ? (
                 <Image
                   src={makeImageUrl(auction.user.avatar, "avatar")}
@@ -515,17 +515,17 @@ const AuctionDetailClient = () => {
                   alt=""
                 />
               ) : (
-                <div className="w-10 h-10 rounded-full bg-gray-200" />
+                <div className="h-10 w-10 rounded-full bg-gray-200 dark:bg-slate-700" />
               )}
               <div>
-                <p className="text-sm font-semibold text-gray-900">{auction.user?.name}</p>
-                <p className="text-xs text-gray-400">경매 등록자</p>
+                <p className="text-sm font-semibold text-gray-900 dark:text-slate-100">{auction.user?.name}</p>
+                <p className="text-xs text-gray-400 dark:text-slate-500">경매 등록자</p>
               </div>
             </div>
           ) : (
             <Link
               href={`/profiles/${auction.user?.id}`}
-              className="flex items-center gap-3 py-4 border-b border-gray-100"
+              className="flex items-center gap-3 border-b border-gray-100 py-4 dark:border-slate-800"
             >
               {auction.user?.avatar ? (
                 <Image
@@ -536,17 +536,17 @@ const AuctionDetailClient = () => {
                   alt=""
                 />
               ) : (
-                <div className="w-10 h-10 rounded-full bg-gray-200" />
+                <div className="h-10 w-10 rounded-full bg-gray-200 dark:bg-slate-700" />
               )}
               <div>
-                <p className="text-sm font-semibold text-gray-900">{auction.user?.name}</p>
-                <p className="text-xs text-gray-400">경매 등록자</p>
+                <p className="text-sm font-semibold text-gray-900 dark:text-slate-100">{auction.user?.name}</p>
+                <p className="text-xs text-gray-400 dark:text-slate-500">경매 등록자</p>
               </div>
             </Link>
           )}
 
           {/* 상품 정보 */}
-          <div className="py-4 space-y-3 border-b border-gray-100">
+          <div className="space-y-3 border-b border-gray-100 py-4 dark:border-slate-800">
             <div className="flex items-center gap-2">
               {auction.category && (
                 <span className="text-xs font-medium text-primary bg-primary/10 px-2 py-0.5 rounded">
@@ -558,13 +558,13 @@ const AuctionDetailClient = () => {
                   "text-xs px-2 py-0.5 rounded-full font-medium",
                   auction.status === "진행중"
                     ? "bg-green-100 text-green-700"
-                    : "bg-gray-200 text-gray-500"
+                    : "bg-gray-200 text-gray-500 dark:bg-slate-700 dark:text-slate-300"
                 )}
               >
                 {auction.status}
               </span>
             </div>
-            <h1 className="text-lg font-bold text-gray-900 break-words [overflow-wrap:anywhere]">
+            <h1 className="text-lg font-bold text-gray-900 break-words [overflow-wrap:anywhere] dark:text-slate-50">
               {auction.title}
             </h1>
             <p className="text-sm text-gray-600 dark:text-slate-300 whitespace-pre-line leading-relaxed break-words [overflow-wrap:anywhere]">
@@ -595,7 +595,7 @@ const AuctionDetailClient = () => {
               </button>
             </div>
             {data?.isOwner && !data?.canEdit ? (
-              <p className="text-xs text-slate-500">
+              <p className="text-xs text-slate-500 dark:text-slate-400">
                 진행중 상태에서 등록 후 10분 이내, 입찰이 없을 때만 수정할 수 있습니다.
               </p>
             ) : null}
@@ -606,9 +606,9 @@ const AuctionDetailClient = () => {
               auction.sellerBandNick ||
               auction.sellerTrustNote ||
               auction.sellerProofImage) && (
-              <div className="rounded-lg border border-slate-200 bg-slate-50 px-3.5 py-3">
-                <p className="text-xs font-semibold text-slate-700">판매자 신뢰 정보</p>
-                <div className="mt-2 space-y-1 text-xs text-slate-600">
+              <div className="rounded-lg border border-slate-200 bg-slate-50 px-3.5 py-3 dark:border-slate-700 dark:bg-slate-800/70">
+                <p className="text-xs font-semibold text-slate-700 dark:text-slate-200">판매자 신뢰 정보</p>
+                <div className="mt-2 space-y-1 text-xs text-slate-600 dark:text-slate-300">
                   {auction.sellerPhone ? <p>연락처: {auction.sellerPhone}</p> : null}
                   {auction.sellerEmail ? <p>이메일: {auction.sellerEmail}</p> : null}
                   {auction.sellerBlogUrl ? (
@@ -630,7 +630,7 @@ const AuctionDetailClient = () => {
                   ) : null}
                 </div>
                 {auction.sellerProofImage ? (
-                  <div className="relative mt-2 h-28 w-40 overflow-hidden rounded-md border border-slate-200">
+                  <div className="relative mt-2 h-28 w-40 overflow-hidden rounded-md border border-slate-200 dark:border-slate-700">
                     <Image
                       src={makeImageUrl(auction.sellerProofImage, "public")}
                       className="object-cover"
@@ -647,11 +647,11 @@ const AuctionDetailClient = () => {
           <div className="py-4 space-y-4">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-xs text-gray-400">시작가</p>
-                <p className="text-sm text-gray-500">{auction.startPrice.toLocaleString()}원</p>
+                <p className="text-xs text-gray-400 dark:text-slate-500">시작가</p>
+                <p className="text-sm text-gray-500 dark:text-slate-300">{auction.startPrice.toLocaleString()}원</p>
               </div>
               <div className="text-right">
-                <p className="text-xs text-gray-400">현재 최고가</p>
+                <p className="text-xs text-gray-400 dark:text-slate-500">현재 최고가</p>
                 <p className="text-2xl font-bold text-primary">
                   {auction.currentPrice.toLocaleString()}원
                 </p>
@@ -660,7 +660,7 @@ const AuctionDetailClient = () => {
 
             <div className="rounded-xl border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-800/70 px-3.5 py-3">
               <div className="flex items-center justify-between gap-3">
-                <p className="text-sm font-semibold text-slate-800">경매 규칙</p>
+                <p className="text-sm font-semibold text-slate-800 dark:text-slate-100">경매 규칙</p>
                 {!isToolRoute ? (
                   <Link
                     href="/auctions/rules"
@@ -670,13 +670,13 @@ const AuctionDetailClient = () => {
                   </Link>
                 ) : null}
               </div>
-              <ul className="mt-2 space-y-1 text-xs text-slate-600">
+              <ul className="mt-2 space-y-1 text-xs text-slate-600 dark:text-slate-300">
                 <li>• 현재가 기준 입찰 단위: {getBidIncrement(auction.currentPrice).toLocaleString()}원</li>
                 <li>• 마감 {extensionWindowMinutes}분 이내 입찰 시 종료 시간이 {extensionMinutes}분 연장됩니다.</li>
                 <li>• 입찰은 취소할 수 없으며, 본인 경매 입찰은 불가합니다.</li>
                 <li>• 현재 최고 입찰자는 재입찰할 수 없습니다.</li>
               </ul>
-              <div className="mt-3 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2.5 text-xs text-amber-900">
+              <div className="mt-3 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2.5 text-xs text-amber-900 dark:border-amber-700 dark:bg-amber-950/40 dark:text-amber-200">
                 <p className="font-semibold">분쟁/신고 안내</p>
                 <p className="mt-1 leading-relaxed">
                   본 서비스는 거래 당사자 간 분쟁에 대해 법적 책임을 지지 않습니다.
@@ -694,15 +694,15 @@ const AuctionDetailClient = () => {
                   </a>
                 ) : null}
                 {!data?.isOwner && (
-                  <div className="mt-3 rounded-lg border border-amber-300 bg-white/70 p-2.5">
-                    <p className="text-[11px] font-semibold text-amber-900">빠른 신고 접수</p>
+                  <div className="mt-3 rounded-lg border border-amber-300 bg-white/70 p-2.5 dark:border-amber-700 dark:bg-slate-900/65">
+                    <p className="text-[11px] font-semibold text-amber-900 dark:text-amber-200">빠른 신고 접수</p>
                     <div className="mt-1.5 space-y-1.5">
                       <select
                         value={reportReason}
                         onChange={(event) =>
                           setReportReason(event.target.value as (typeof REPORT_REASONS)[number])
                         }
-                        className="w-full rounded-md border border-amber-200 bg-white px-2 py-1.5 text-[11px]"
+                        className="w-full rounded-md border border-amber-200 bg-white px-2 py-1.5 text-[11px] dark:border-amber-700 dark:bg-slate-900 dark:text-slate-100"
                       >
                         {REPORT_REASONS.map((reason) => (
                           <option key={reason} value={reason}>
@@ -715,7 +715,7 @@ const AuctionDetailClient = () => {
                         onChange={(event) => setReportDetail(event.target.value)}
                         placeholder="신고 내용을 5자 이상 입력해주세요."
                         rows={2}
-                        className="w-full rounded-md border border-amber-200 bg-white px-2 py-1.5 text-[11px]"
+                        className="w-full rounded-md border border-amber-200 bg-white px-2 py-1.5 text-[11px] dark:border-amber-700 dark:bg-slate-900 dark:text-slate-100 dark:placeholder:text-slate-500"
                       />
                       <button
                         type="button"
@@ -743,7 +743,9 @@ const AuctionDetailClient = () => {
                       key={bid.id}
                       className={cn(
                         "flex items-center justify-between py-2 px-3 rounded-lg",
-                        i === 0 ? "bg-primary/5 border border-primary/20" : "bg-gray-50"
+                        i === 0
+                          ? "border border-primary/20 bg-primary/5 dark:border-primary/30 dark:bg-primary/10"
+                          : "bg-gray-50 dark:bg-slate-800/70"
                       )}
                     >
                       <div className="flex items-center gap-2">
@@ -763,15 +765,15 @@ const AuctionDetailClient = () => {
                             alt=""
                           />
                         ) : (
-                          <div className="w-6 h-6 rounded-full bg-gray-200" />
+                          <div className="h-6 w-6 rounded-full bg-gray-200 dark:bg-slate-700" />
                         )}
-                        <span className="text-sm text-gray-700">{bid.user?.name}</span>
+                        <span className="text-sm text-gray-700 dark:text-slate-200">{bid.user?.name}</span>
                       </div>
                       <div className="text-right">
-                        <p className="text-sm font-semibold text-gray-900">
+                        <p className="text-sm font-semibold text-gray-900 dark:text-slate-100">
                           {bid.amount.toLocaleString()}원
                         </p>
-                        <p className="text-xs text-gray-400">
+                        <p className="text-xs text-gray-400 dark:text-slate-500">
                           {getTimeAgoString(new Date(bid.createdAt))}
                         </p>
                       </div>
@@ -779,7 +781,7 @@ const AuctionDetailClient = () => {
                   ))}
                 </div>
               ) : (
-                <p className="text-sm text-gray-400 dark:text-slate-500 text-center py-4">
+                <p className="py-4 text-center text-sm text-gray-400 dark:text-slate-500">
                   아직 입찰 내역이 없습니다
                 </p>
               )}
@@ -817,50 +819,50 @@ const AuctionDetailClient = () => {
                 <button
                   onClick={() => increaseBidAmount(bidIncrement)}
                   disabled={isTopBidder}
-                  className="rounded-lg bg-gray-100 px-2 py-2 text-[11px] font-semibold text-gray-700 transition-colors hover:bg-gray-200 disabled:cursor-not-allowed disabled:opacity-50"
+                  className="rounded-lg bg-gray-100 px-2 py-2 text-[11px] font-semibold text-gray-700 transition-colors hover:bg-gray-200 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-slate-700 dark:text-slate-100 dark:hover:bg-slate-600"
                 >
                   +1틱
                 </button>
                 <button
                   onClick={() => increaseBidAmount(bidIncrement * 2)}
                   disabled={isTopBidder}
-                  className="rounded-lg bg-gray-100 px-2 py-2 text-[11px] font-semibold text-gray-700 transition-colors hover:bg-gray-200 disabled:cursor-not-allowed disabled:opacity-50"
+                  className="rounded-lg bg-gray-100 px-2 py-2 text-[11px] font-semibold text-gray-700 transition-colors hover:bg-gray-200 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-slate-700 dark:text-slate-100 dark:hover:bg-slate-600"
                 >
                   +2틱
                 </button>
                 <button
                   onClick={() => increaseBidAmount(10_000)}
                   disabled={isTopBidder}
-                  className="rounded-lg bg-gray-100 px-2 py-2 text-[11px] font-semibold text-gray-700 transition-colors hover:bg-gray-200 disabled:cursor-not-allowed disabled:opacity-50"
+                  className="rounded-lg bg-gray-100 px-2 py-2 text-[11px] font-semibold text-gray-700 transition-colors hover:bg-gray-200 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-slate-700 dark:text-slate-100 dark:hover:bg-slate-600"
                 >
                   +10,000원
                 </button>
                 <button
                   onClick={() => increaseBidAmount(50_000)}
                   disabled={isTopBidder}
-                  className="rounded-lg bg-gray-100 px-2 py-2 text-[11px] font-semibold text-gray-700 transition-colors hover:bg-gray-200 disabled:cursor-not-allowed disabled:opacity-50"
+                  className="rounded-lg bg-gray-100 px-2 py-2 text-[11px] font-semibold text-gray-700 transition-colors hover:bg-gray-200 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-slate-700 dark:text-slate-100 dark:hover:bg-slate-600"
                 >
                   +50,000원
                 </button>
                 <button
                   onClick={() => increaseBidAmount(100_000)}
                   disabled={isTopBidder}
-                  className="rounded-lg bg-gray-100 px-2 py-2 text-[11px] font-semibold text-gray-700 transition-colors hover:bg-gray-200 disabled:cursor-not-allowed disabled:opacity-50"
+                  className="rounded-lg bg-gray-100 px-2 py-2 text-[11px] font-semibold text-gray-700 transition-colors hover:bg-gray-200 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-slate-700 dark:text-slate-100 dark:hover:bg-slate-600"
                 >
                   +100,000원
                 </button>
                 <button
                   onClick={() => setBidAmount(minimumBid)}
                   disabled={isTopBidder}
-                  className="rounded-lg bg-gray-100 px-2 py-2 text-[11px] font-semibold text-gray-700 transition-colors hover:bg-gray-200 disabled:cursor-not-allowed disabled:opacity-50"
+                  className="rounded-lg bg-gray-100 px-2 py-2 text-[11px] font-semibold text-gray-700 transition-colors hover:bg-gray-200 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-slate-700 dark:text-slate-100 dark:hover:bg-slate-600"
                 >
                   최소가
                 </button>
               </div>
               <div className="flex items-center gap-2">
-                <div className="flex-1 rounded-lg bg-gray-100 px-3 py-2 text-right">
-                  <p className="text-[10px] font-medium text-gray-500">선택 입찰가</p>
-                  <p className="text-sm font-bold text-gray-900">
+                <div className="flex-1 rounded-lg bg-gray-100 px-3 py-2 text-right dark:bg-slate-800">
+                  <p className="text-[10px] font-medium text-gray-500 dark:text-slate-400">선택 입찰가</p>
+                  <p className="text-sm font-bold text-gray-900 dark:text-slate-100">
                     {selectedBidAmount.toLocaleString()}원
                   </p>
                 </div>
@@ -876,7 +878,7 @@ const AuctionDetailClient = () => {
               </div>
             </div>
             {isTopBidder ? (
-              <p className="mt-2 text-[11px] text-amber-700">
+              <p className="mt-2 text-[11px] text-amber-700 dark:text-amber-300">
                 현재 최고 입찰자는 다시 입찰할 수 없습니다. 다른 참여자의 입찰을 기다려주세요.
               </p>
             ) : null}


### PR DESCRIPTION
## 목적
- 경매 페이지 다크모드에서 텍스트/배경 대비가 낮아 가독성이 떨어지는 문제를 개선합니다.

## 변경 사항
- 경매 목록(`/auctions`) 상단 카드/탭/검색/아이템 카드의 다크모드 색상 대비 보강
- 경매 상세(`/auctions/[id]`) 카운트다운, 판매자 정보, 경매 규칙, 입찰 내역, 하단 입찰 패널의 다크모드 텍스트 가독성 개선
- 저대비 `text-gray-*`, `bg-white`, `bg-gray-*` 위주 클래스에 `dark:*` 대응 추가

## 검증
- `npm run verify:ci` 통과
