### PR TITLE
브리디북 카드 오버플로우 스타일 수정

### DIFF
--- a/app/(web)/posts/PostsClient.tsx
+++ b/app/(web)/posts/PostsClient.tsx
@@ -220,7 +220,7 @@ export default function PostsClient() {
                   <Link
                     key={record.id}
                     href="/guinness"
-                    className="snap-start shrink-0 w-56 app-card app-card-interactive p-4"
+                    className="snap-start shrink-0 w-56 app-card app-card-interactive overflow-hidden p-4"
                   >
                     <div className="flex items-start justify-between">
                       <span
@@ -265,7 +265,7 @@ export default function PostsClient() {
               [...Array(3)].map((_, i) => (
                 <div
                   key={i}
-                  className="snap-start shrink-0 w-56 app-card p-4 animate-pulse"
+                  className="snap-start shrink-0 w-56 app-card overflow-hidden p-4 animate-pulse"
                 >
                   <div className="h-7 w-7 rounded-full bg-gray-200" />
                   <div className="mt-3 h-4 bg-gray-200 rounded w-2/5" />


### PR DESCRIPTION
## 변경 내용
- `/posts` 화면의 브리디북 미리보기 카드에 `overflow-hidden`을 적용했습니다.
- 스켈레톤 카드에도 동일하게 `overflow-hidden`을 적용해 긴 체장 텍스트가 카드 밖으로 넘치지 않도록 수정했습니다.

## 검증
- `npm run lint -- --file app/(web)/posts/PostsClient.tsx` 통과

## 영향 범위
- `/posts` 브리디북 미리보기 UI
