### PR TITLE
feat: 고객의 소리 접수 채널 및 어드민 운영 기능 추가

### DIFF
--- a/app/(web)/settings/SettingsClient.tsx
+++ b/app/(web)/settings/SettingsClient.tsx
@@ -380,6 +380,19 @@ const SettingsClient = () => {
           ),
         },
         {
+          label: "고객의 소리",
+          href: "/support",
+          description: "버그 제보/기능 요청/비즈니스 문의 안내",
+          icon: (
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth="2"
+              d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-4l-3 3-3-3z"
+            />
+          ),
+        },
+        {
           label: "앱 버전",
           description: "1.0.0",
           icon: (

--- a/app/(web)/support/page.tsx
+++ b/app/(web)/support/page.tsx
@@ -1,0 +1,201 @@
+"use client";
+
+import { FormEvent, useMemo, useState } from "react";
+import Link from "next/link";
+import Layout from "@components/features/MainLayout";
+import { Button } from "@components/ui/button";
+import { Input } from "@components/ui/input";
+import { Textarea } from "@components/ui/textarea";
+import useUser from "hooks/useUser";
+
+type VoiceType = "BUG_REPORT" | "FEATURE_REQUEST" | "DEV_TEAM_REQUEST";
+
+const FEEDBACK_TYPE_OPTIONS: { value: VoiceType; label: string; hint: string }[] = [
+  {
+    value: "BUG_REPORT",
+    label: "버그 제보",
+    hint: "재현 순서와 실제 발생 상황을 최대한 자세히 남겨주세요.",
+  },
+  {
+    value: "FEATURE_REQUEST",
+    label: "기능 요청",
+    hint: "불편한 점과 원하는 개선 방향을 함께 적어주세요.",
+  },
+  {
+    value: "DEV_TEAM_REQUEST",
+    label: "개발팀 요청하기",
+    hint: "기술 협업/기능 연동 등 개발팀 검토가 필요한 요청을 남겨주세요.",
+  },
+];
+
+const BUSINESS_EMAIL = "bredyteam@gmail.com";
+const INSTAGRAM_URL =
+  "https://www.instagram.com/bredy_breeder?igsh=OWZobjN0c3NhdXlk";
+
+export default function SupportPage() {
+  const { user } = useUser();
+  const [type, setType] = useState<VoiceType>("BUG_REPORT");
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [contactEmail, setContactEmail] = useState(String(user?.email || ""));
+  const [submitting, setSubmitting] = useState(false);
+  const [message, setMessage] = useState("");
+  const [error, setError] = useState("");
+
+  const selectedType = useMemo(
+    () => FEEDBACK_TYPE_OPTIONS.find((option) => option.value === type),
+    [type]
+  );
+
+  const handleSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    setMessage("");
+    setError("");
+
+    if (!title.trim() || !description.trim() || !contactEmail.trim()) {
+      setError("문의 유형, 제목, 상세 내용, 회신 이메일을 모두 입력해주세요.");
+      return;
+    }
+
+    try {
+      setSubmitting(true);
+      const res = await fetch("/api/voice/inquiries", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          type,
+          title: title.trim(),
+          description: description.trim(),
+          contactEmail: contactEmail.trim(),
+        }),
+      });
+      const result = await res.json();
+      if (!res.ok || !result.success) {
+        throw new Error(result.error || "접수에 실패했습니다.");
+      }
+      setTitle("");
+      setDescription("");
+      setMessage("접수가 완료되었습니다. 검토 후 등록한 이메일로 답변드리겠습니다.");
+    } catch (submitError) {
+      setError(submitError instanceof Error ? submitError.message : "요청 중 오류가 발생했습니다.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Layout canGoBack title="고객의 소리" seoTitle="고객의 소리">
+      <div className="space-y-4 px-4 py-4 pb-12">
+        <section className="rounded-xl border border-slate-200 bg-white p-4">
+          <h2 className="text-base font-bold text-slate-900">접수 채널 안내</h2>
+          <p className="mt-2 text-sm leading-relaxed text-slate-700">
+            운영 안정성을 위해 접수 채널을 분리해서 운영합니다.
+            버그 제보/기능 요청은 아래 폼으로, 투자/광고/콜라보는 비즈니스 채널로 문의해주세요.
+          </p>
+          <div className="mt-3 rounded-lg border border-emerald-200 bg-emerald-50 p-3 text-sm text-emerald-900">
+            버그 제보 · 기능 요청 · 개발팀 요청하기: 이 페이지 접수 폼 사용
+          </div>
+          <div className="mt-2 rounded-lg border border-blue-200 bg-blue-50 p-3 text-sm text-blue-900">
+            투자/광고/콜라보 문의:{" "}
+            <a
+              className="font-semibold underline underline-offset-2"
+              href={`mailto:${BUSINESS_EMAIL}?subject=[비즈니스%20문의]%20브리디%20협업%20문의`}
+            >
+              {BUSINESS_EMAIL}
+            </a>
+            {" "}또는{" "}
+            <a
+              className="font-semibold underline underline-offset-2"
+              href={INSTAGRAM_URL}
+              target="_blank"
+              rel="noreferrer"
+            >
+              공식 인스타그램 DM
+            </a>
+          </div>
+        </section>
+
+        <form
+          onSubmit={handleSubmit}
+          className="space-y-3 rounded-xl border border-slate-200 bg-white p-4"
+        >
+          <h3 className="text-sm font-semibold text-slate-900">제품 의견 접수</h3>
+
+          <div className="space-y-2">
+            <p className="text-xs font-semibold text-slate-700">문의 유형</p>
+            <div className="flex flex-wrap gap-2">
+              {FEEDBACK_TYPE_OPTIONS.map((option) => (
+                <button
+                  key={option.value}
+                  type="button"
+                  onClick={() => setType(option.value)}
+                  className={
+                    type === option.value
+                      ? "rounded-full bg-slate-900 px-3 py-1.5 text-xs font-semibold text-white"
+                      : "rounded-full border border-slate-200 px-3 py-1.5 text-xs font-semibold text-slate-700"
+                  }
+                >
+                  {option.label}
+                </button>
+              ))}
+            </div>
+            <p className="text-xs text-slate-500">{selectedType?.hint}</p>
+          </div>
+
+          <Input
+            value={title}
+            onChange={(event) => setTitle(event.target.value)}
+            placeholder="제목 (2~80자)"
+          />
+          <Textarea
+            value={description}
+            onChange={(event) => setDescription(event.target.value)}
+            placeholder="상세 내용 (10~2000자)"
+            rows={7}
+          />
+          <Input
+            type="email"
+            value={contactEmail}
+            onChange={(event) => setContactEmail(event.target.value)}
+            placeholder="회신 받을 이메일"
+          />
+
+          {message ? (
+            <p className="rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm text-emerald-800">
+              {message}
+            </p>
+          ) : null}
+          {error ? (
+            <p className="rounded-md border border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-800">
+              {error}
+            </p>
+          ) : null}
+
+          <Button type="submit" disabled={submitting}>
+            {submitting ? "접수 중..." : "접수하기"}
+          </Button>
+        </form>
+
+        <section className="rounded-xl border border-slate-200 bg-slate-50 p-4 text-sm text-slate-700">
+          <p className="font-semibold text-slate-900">비즈니스 문의 시 포함하면 좋은 정보</p>
+          <ul className="mt-2 space-y-1 leading-relaxed">
+            <li>• 회사/브랜드명, 담당자명</li>
+            <li>• 문의 유형 (투자/광고/콜라보)</li>
+            <li>• 목적과 기대 효과</li>
+            <li>• 예산/일정 (가능한 범위)</li>
+          </ul>
+          <p className="mt-3">
+            랜딩/프로모션 참고 자료는{" "}
+            <Link
+              href="/auction-tool"
+              className="font-semibold underline underline-offset-2"
+            >
+              서비스 소개 페이지
+            </Link>
+            에서 확인할 수 있습니다.
+          </p>
+        </section>
+      </div>
+    </Layout>
+  );
+}

--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -13,6 +13,7 @@ const ADMIN_MENUS = [
   { name: "랜딩 페이지", href: "/admin/landing-pages" },
   { name: "기네스북 심사", href: "/admin/guinness" },
   { name: "유저 관리", href: "/admin/users" },
+  { name: "고객의 소리", href: "/admin/voice" },
   { name: "게시물 관리", href: "/admin/posts" }, // 추후 구현
   { name: "상품 관리", href: "/admin/products" },
 ];

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -77,6 +77,11 @@ const DASHBOARD_MENUS = [
     href: "/admin/posts",
   },
   {
+    title: "고객의 소리",
+    description: "버그 제보/기능 요청/개발팀 요청 접수 상태를 확인하고 응답합니다.",
+    href: "/admin/voice",
+  },
+  {
     title: "상품 관리",
     description: "상품 검색, 확인, 삭제를 수행합니다.",
     href: "/admin/products",

--- a/app/admin/voice/page.tsx
+++ b/app/admin/voice/page.tsx
@@ -1,0 +1,190 @@
+"use client";
+
+import { useState } from "react";
+import useSWR from "swr";
+import { VoiceInquiryStatus, VoiceInquiryType } from "@prisma/client";
+import { Button } from "@components/ui/button";
+import { Textarea } from "@components/ui/textarea";
+import { toast } from "react-toastify";
+
+interface VoiceInquiryItem {
+  id: number;
+  type: VoiceInquiryType;
+  status: VoiceInquiryStatus;
+  title: string;
+  description: string;
+  contactEmail: string;
+  requesterId: number | null;
+  requesterName: string | null;
+  adminNote: string | null;
+  createdAt: string | Date;
+  updatedAt: string | Date;
+}
+
+interface VoiceInquiryResponse {
+  success: boolean;
+  inquiries: VoiceInquiryItem[];
+  counts: Record<VoiceInquiryStatus, number>;
+  error?: string;
+}
+
+const STATUS_OPTIONS: (VoiceInquiryStatus | "ALL")[] = [
+  "ALL",
+  "OPEN",
+  "IN_REVIEW",
+  "DONE",
+  "REJECTED",
+];
+
+const TYPE_LABEL: Record<VoiceInquiryType, string> = {
+  BUG_REPORT: "버그 제보",
+  FEATURE_REQUEST: "기능 요청",
+  DEV_TEAM_REQUEST: "개발팀 요청",
+};
+
+const STATUS_LABEL: Record<VoiceInquiryStatus, string> = {
+  OPEN: "접수됨",
+  IN_REVIEW: "검토중",
+  DONE: "완료",
+  REJECTED: "보류/반려",
+};
+
+export default function AdminVoicePage() {
+  const [statusFilter, setStatusFilter] = useState<VoiceInquiryStatus | "ALL">("ALL");
+  const [updatingId, setUpdatingId] = useState<number | null>(null);
+  const [noteById, setNoteById] = useState<Record<number, string>>({});
+
+  const query = statusFilter === "ALL" ? "" : `?status=${statusFilter}`;
+  const { data, mutate, isLoading } = useSWR<VoiceInquiryResponse>(
+    `/api/admin/voice-inquiries${query}`
+  );
+
+  const handleUpdateStatus = async (inquiry: VoiceInquiryItem, nextStatus: VoiceInquiryStatus) => {
+    try {
+      setUpdatingId(inquiry.id);
+      const res = await fetch("/api/admin/voice-inquiries", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          id: inquiry.id,
+          status: nextStatus,
+          adminNote: noteById[inquiry.id] ?? inquiry.adminNote ?? "",
+        }),
+      });
+      const result = await res.json();
+      if (!res.ok || !result.success) {
+        return toast.error(result.error || "상태 변경에 실패했습니다.");
+      }
+      toast.success("상태를 변경했습니다.");
+      mutate();
+    } catch {
+      toast.error("요청 중 오류가 발생했습니다.");
+    } finally {
+      setUpdatingId(null);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <h2 className="text-2xl font-bold text-gray-900">고객의 소리 관리</h2>
+        <div className="flex flex-wrap gap-2">
+          {STATUS_OPTIONS.map((status) => (
+            <button
+              key={status}
+              type="button"
+              onClick={() => setStatusFilter(status)}
+              className={
+                statusFilter === status
+                  ? "rounded-full bg-gray-900 px-3 py-1.5 text-xs font-semibold text-white"
+                  : "rounded-full border border-gray-200 bg-white px-3 py-1.5 text-xs font-semibold text-gray-700"
+              }
+            >
+              {status === "ALL" ? "전체" : STATUS_LABEL[status]}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="rounded-lg border border-gray-200 bg-white p-3 text-xs text-gray-600">
+        접수 현황: OPEN {data?.counts?.OPEN ?? 0} / IN_REVIEW {data?.counts?.IN_REVIEW ?? 0} / DONE{" "}
+        {data?.counts?.DONE ?? 0} / REJECTED {data?.counts?.REJECTED ?? 0}
+      </div>
+
+      {isLoading ? <p className="text-sm text-gray-500">불러오는 중...</p> : null}
+
+      <div className="space-y-3">
+        {(data?.inquiries || []).map((inquiry) => (
+          <div
+            key={inquiry.id}
+            className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm"
+          >
+            <div className="flex flex-wrap items-center gap-2 text-xs text-gray-500">
+              <span className="font-semibold text-gray-700">#{inquiry.id}</span>
+              <span>{TYPE_LABEL[inquiry.type]}</span>
+              <span>상태: {STATUS_LABEL[inquiry.status]}</span>
+              <span>접수일: {new Date(inquiry.createdAt).toLocaleString()}</span>
+            </div>
+
+            <p className="mt-2 text-sm font-semibold text-gray-900">{inquiry.title}</p>
+            <p className="mt-1 whitespace-pre-line text-sm text-gray-700">{inquiry.description}</p>
+            <p className="mt-2 text-xs text-gray-500">
+              회신 이메일: {inquiry.contactEmail} / 요청자:{" "}
+              {inquiry.requesterName || (inquiry.requesterId ? `ID ${inquiry.requesterId}` : "비로그인")}
+            </p>
+
+            <div className="mt-3 space-y-2">
+              <Textarea
+                rows={3}
+                placeholder="내부 메모 (선택)"
+                value={noteById[inquiry.id] ?? inquiry.adminNote ?? ""}
+                onChange={(event) =>
+                  setNoteById((prev) => ({ ...prev, [inquiry.id]: event.target.value }))
+                }
+              />
+              <div className="flex flex-wrap gap-2">
+                <Button
+                  size="sm"
+                  variant="outline"
+                  disabled={updatingId === inquiry.id}
+                  onClick={() => handleUpdateStatus(inquiry, "IN_REVIEW")}
+                >
+                  검토중
+                </Button>
+                <Button
+                  size="sm"
+                  disabled={updatingId === inquiry.id}
+                  onClick={() => handleUpdateStatus(inquiry, "DONE")}
+                >
+                  완료
+                </Button>
+                <Button
+                  size="sm"
+                  variant="destructive"
+                  disabled={updatingId === inquiry.id}
+                  onClick={() => handleUpdateStatus(inquiry, "REJECTED")}
+                >
+                  보류/반려
+                </Button>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  disabled={updatingId === inquiry.id}
+                  onClick={() => handleUpdateStatus(inquiry, "OPEN")}
+                >
+                  접수됨으로 복귀
+                </Button>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {!isLoading && (data?.inquiries?.length || 0) === 0 ? (
+        <div className="rounded-lg border border-dashed border-gray-300 bg-white p-8 text-center text-sm text-gray-500">
+          조건에 맞는 접수 내역이 없습니다.
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/libs/server/withHandler.ts
+++ b/libs/server/withHandler.ts
@@ -7,7 +7,7 @@ export interface ResponseType {
   [key: string]: any;
 }
 
-type method = "GET" | "POST" | "DELETE";
+type method = "GET" | "POST" | "DELETE" | "PATCH";
 
 interface ConfigType {
   methods: method[];

--- a/pages/api/admin/voice-inquiries.ts
+++ b/pages/api/admin/voice-inquiries.ts
@@ -1,0 +1,169 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import withHandler, { ResponseType } from "@libs/server/withHandler";
+import { withApiSession } from "@libs/server/withSession";
+import client from "@libs/server/client";
+import { hasAdminAccess } from "./_utils";
+import { VoiceInquiryStatus, VoiceInquiryType } from "@prisma/client";
+
+interface VoiceInquiryAdminItem {
+  id: number;
+  type: VoiceInquiryType;
+  status: VoiceInquiryStatus;
+  title: string;
+  description: string;
+  contactEmail: string;
+  requesterId: number | null;
+  requesterName: string | null;
+  adminNote: string | null;
+  createdAt: string | Date;
+  updatedAt: string | Date;
+}
+
+interface VoiceInquiryAdminResponse extends ResponseType {
+  inquiries: VoiceInquiryAdminItem[];
+  counts: Record<VoiceInquiryStatus, number>;
+  error?: string;
+}
+
+const STATUS_SET = new Set<VoiceInquiryStatus>([
+  "OPEN",
+  "IN_REVIEW",
+  "DONE",
+  "REJECTED",
+]);
+const TYPE_SET = new Set<VoiceInquiryType>([
+  "BUG_REPORT",
+  "FEATURE_REQUEST",
+  "DEV_TEAM_REQUEST",
+]);
+
+const EMPTY_COUNTS: Record<VoiceInquiryStatus, number> = {
+  OPEN: 0,
+  IN_REVIEW: 0,
+  DONE: 0,
+  REJECTED: 0,
+};
+
+async function getCounts() {
+  const grouped = await client.voiceInquiry.groupBy({
+    by: ["status"],
+    _count: { _all: true },
+  });
+  return grouped.reduce<Record<VoiceInquiryStatus, number>>((acc, item) => {
+    acc[item.status] = item._count._all;
+    return acc;
+  }, { ...EMPTY_COUNTS });
+}
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<VoiceInquiryAdminResponse>
+) {
+  const adminId = req.session.user?.id;
+  const isAdmin = await hasAdminAccess(adminId);
+  if (!isAdmin) {
+    return res.status(403).json({
+      success: false,
+      error: "접근 권한이 없습니다.",
+      inquiries: [],
+      counts: EMPTY_COUNTS,
+    });
+  }
+
+  if (req.method === "GET") {
+    const status = String(req.query.status || "ALL");
+    const type = String(req.query.type || "ALL");
+
+    const where = {
+      ...(status === "ALL" || !STATUS_SET.has(status as VoiceInquiryStatus)
+        ? {}
+        : { status: status as VoiceInquiryStatus }),
+      ...(type === "ALL" || !TYPE_SET.has(type as VoiceInquiryType)
+        ? {}
+        : { type: type as VoiceInquiryType }),
+    };
+
+    const [inquiries, counts] = await Promise.all([
+      client.voiceInquiry.findMany({
+        where,
+        orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+      }),
+      getCounts(),
+    ]);
+
+    return res.json({
+      success: true,
+      inquiries,
+      counts,
+    });
+  }
+
+  if (req.method === "POST") {
+    const { id, status, adminNote } = req.body || {};
+    const inquiryId = Number(id);
+    const nextStatus = String(status || "") as VoiceInquiryStatus;
+    const nextAdminNote = String(adminNote || "").trim().slice(0, 500);
+
+    if (!inquiryId || Number.isNaN(inquiryId)) {
+      return res.status(400).json({
+        success: false,
+        error: "유효한 문의 ID가 필요합니다.",
+        inquiries: [],
+        counts: EMPTY_COUNTS,
+      });
+    }
+
+    if (!STATUS_SET.has(nextStatus)) {
+      return res.status(400).json({
+        success: false,
+        error: "유효하지 않은 상태값입니다.",
+        inquiries: [],
+        counts: EMPTY_COUNTS,
+      });
+    }
+
+    const exists = await client.voiceInquiry.findUnique({
+      where: { id: inquiryId },
+      select: { id: true },
+    });
+    if (!exists) {
+      return res.status(404).json({
+        success: false,
+        error: "문의를 찾을 수 없습니다.",
+        inquiries: [],
+        counts: EMPTY_COUNTS,
+      });
+    }
+
+    const updated = await client.voiceInquiry.update({
+      where: { id: inquiryId },
+      data: {
+        status: nextStatus,
+        adminNote: nextAdminNote || null,
+      },
+    });
+
+    const counts = await getCounts();
+
+    return res.json({
+      success: true,
+      inquiries: [updated],
+      counts,
+    });
+  }
+
+  return res.status(405).json({
+    success: false,
+    error: "지원하지 않는 메서드입니다.",
+    inquiries: [],
+    counts: EMPTY_COUNTS,
+  });
+}
+
+export default withApiSession(
+  withHandler({
+    methods: ["GET", "POST"],
+    isPrivate: false,
+    handler,
+  })
+);

--- a/pages/api/voice/inquiries.ts
+++ b/pages/api/voice/inquiries.ts
@@ -1,0 +1,85 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import withHandler, { ResponseType } from "@libs/server/withHandler";
+import { withApiSession } from "@libs/server/withSession";
+import client from "@libs/server/client";
+import { VoiceInquiryType } from "@prisma/client";
+
+interface VoiceInquiryCreateResponse extends ResponseType {
+  error?: string;
+  inquiryId?: number;
+}
+
+const ALLOWED_TYPES = new Set<VoiceInquiryType>([
+  "BUG_REPORT",
+  "FEATURE_REQUEST",
+  "DEV_TEAM_REQUEST",
+]);
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<VoiceInquiryCreateResponse>
+) {
+  const { type, title, description, contactEmail } = req.body || {};
+  const parsedType = String(type || "") as VoiceInquiryType;
+  const parsedTitle = String(title || "").trim();
+  const parsedDescription = String(description || "").trim();
+  const parsedEmail = String(contactEmail || "").trim().toLowerCase();
+
+  if (!ALLOWED_TYPES.has(parsedType)) {
+    return res.status(400).json({
+      success: false,
+      error: "유효하지 않은 문의 유형입니다.",
+    });
+  }
+
+  if (parsedTitle.length < 2 || parsedTitle.length > 80) {
+    return res.status(400).json({
+      success: false,
+      error: "제목은 2자 이상 80자 이하로 입력해주세요.",
+    });
+  }
+
+  if (parsedDescription.length < 10 || parsedDescription.length > 2000) {
+    return res.status(400).json({
+      success: false,
+      error: "상세 내용은 10자 이상 2000자 이하로 입력해주세요.",
+    });
+  }
+
+  if (!EMAIL_REGEX.test(parsedEmail)) {
+    return res.status(400).json({
+      success: false,
+      error: "회신 받을 이메일 형식이 올바르지 않습니다.",
+    });
+  }
+
+  const requesterId = req.session.user?.id || null;
+  const requesterName = String(req.session.user?.name || "").trim() || null;
+
+  const created = await client.voiceInquiry.create({
+    data: {
+      type: parsedType,
+      title: parsedTitle,
+      description: parsedDescription,
+      contactEmail: parsedEmail,
+      requesterId,
+      requesterName,
+    },
+    select: { id: true },
+  });
+
+  return res.json({
+    success: true,
+    inquiryId: created.id,
+  });
+}
+
+export default withApiSession(
+  withHandler({
+    methods: ["POST"],
+    isPrivate: false,
+    handler,
+  })
+);

--- a/prisma/migrations/20260214112000_voice_inquiries/migration.sql
+++ b/prisma/migrations/20260214112000_voice_inquiries/migration.sql
@@ -1,0 +1,28 @@
+-- CreateEnum
+CREATE TYPE "VoiceInquiryType" AS ENUM ('BUG_REPORT', 'FEATURE_REQUEST', 'DEV_TEAM_REQUEST');
+
+-- CreateEnum
+CREATE TYPE "VoiceInquiryStatus" AS ENUM ('OPEN', 'IN_REVIEW', 'DONE', 'REJECTED');
+
+-- CreateTable
+CREATE TABLE "VoiceInquiry" (
+    "id" SERIAL NOT NULL,
+    "type" "VoiceInquiryType" NOT NULL,
+    "status" "VoiceInquiryStatus" NOT NULL DEFAULT 'OPEN',
+    "title" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "contactEmail" TEXT NOT NULL,
+    "requesterId" INTEGER,
+    "requesterName" TEXT,
+    "adminNote" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "VoiceInquiry_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "VoiceInquiry_status_createdAt_idx" ON "VoiceInquiry"("status", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "VoiceInquiry_type_createdAt_idx" ON "VoiceInquiry"("type", "createdAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -534,6 +534,36 @@ model AdminBanner {
   @@index([order])
 }
 
+enum VoiceInquiryType {
+  BUG_REPORT
+  FEATURE_REQUEST
+  DEV_TEAM_REQUEST
+}
+
+enum VoiceInquiryStatus {
+  OPEN
+  IN_REVIEW
+  DONE
+  REJECTED
+}
+
+model VoiceInquiry {
+  id           Int                @id @default(autoincrement())
+  type         VoiceInquiryType
+  status       VoiceInquiryStatus @default(OPEN)
+  title        String
+  description  String
+  contactEmail String
+  requesterId  Int?
+  requesterName String?
+  adminNote    String?
+  createdAt    DateTime           @default(now())
+  updatedAt    DateTime           @updatedAt
+
+  @@index([status, createdAt])
+  @@index([type, createdAt])
+}
+
 model LandingPage {
   id          Int      @id @default(autoincrement())
   slug        String   @unique

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = "bredy-pwa-v1";
+const CACHE_VERSION = "bredy-pwa-v2";
 const STATIC_CACHE = `${CACHE_VERSION}-static`;
 const IMAGE_CACHE = `${CACHE_VERSION}-image`;
 const OFFLINE_URL = "/offline";
@@ -76,22 +76,32 @@ self.addEventListener("fetch", (event) => {
     return;
   }
 
-  if (
-    request.destination === "style" ||
-    request.destination === "script" ||
-    url.pathname.startsWith("/_next/static/")
-  ) {
+  if (url.pathname.startsWith("/_next/static/")) {
     event.respondWith(
-      caches.match(request).then((cached) => {
-        const fetchPromise = fetch(request)
-          .then((response) => {
+      fetch(request)
+        .then((response) => {
+          if (response && response.ok) {
             const copy = response.clone();
             caches.open(STATIC_CACHE).then((cache) => cache.put(request, copy));
-            return response;
-          })
-          .catch(() => cached);
-        return cached || fetchPromise;
-      })
+          }
+          return response;
+        })
+        .catch(() => caches.match(request))
+    );
+    return;
+  }
+
+  if (request.destination === "style" || request.destination === "script") {
+    event.respondWith(
+      fetch(request)
+        .then((response) => {
+          if (response && response.ok) {
+            const copy = response.clone();
+            caches.open(STATIC_CACHE).then((cache) => cache.put(request, copy));
+          }
+          return response;
+        })
+        .catch(() => caches.match(request))
     );
   }
 });


### PR DESCRIPTION
## 변경 내용
- 고객의 소리 페이지(/support)를 추가했습니다.
  - 버그 제보 / 기능 요청 / 개발팀 요청: 앱 내 접수 폼
  - 투자/광고/콜라보: 공식 이메일 + 공식 인스타그램 DM 안내
- 고객의 소리 접수 API를 추가했습니다. (POST /api/voice/inquiries)
- 어드민 고객의 소리 관리 페이지를 추가했습니다. (/admin/voice)
- 어드민 고객의 소리 관리 API를 추가했습니다. (GET/POST /api/admin/voice-inquiries)
- 어드민 메뉴/대시보드/설정에 고객의 소리 진입 링크를 추가했습니다.
- 어드민 배너 순서 변경 기능(위/아래 이동)과 API(PATCH)를 추가했습니다.
- SW 정적 청크 캐시 전략을 개선해 로컬 chunk load 실패 가능성을 낮췄습니다.

## DB 변경
- VoiceInquiry 관련 enum/model 추가
- migration 추가: prisma/migrations/20260214112000_voice_inquiries/migration.sql

## 검증
- npm run lint -- --file ... (관련 파일) 통과
- npm run typecheck 통과