### PR TITLE
fix: 구글 로그인 버튼 개발용 문구 제거

### DIFF
--- a/app/auth/login/LoginClient.tsx
+++ b/app/auth/login/LoginClient.tsx
@@ -186,7 +186,7 @@ const LoginClient = () => {
             className="button relative flex h-[54px] w-full items-center justify-center rounded-lg border border-Gray-300 bg-white px-7 py-[14px]"
           >
             <GoogleRound className="absolute left-7" width={26} height={26} />
-            <span className="title-3">{"구글로 계속하기 (개발용)"}</span>
+            <span className="title-3">{"구글로 계속하기"}</span>
           </button>
         ) : (
           <p className="mt-1 text-[11px] text-Gray-500">


### PR DESCRIPTION
## 변경 내용
- 로그인 페이지의 구글 버튼 문구에서 '(개발용)' 텍스트를 제거했습니다.
- 사용자 노출 문구를 프로덕션 기준으로 정리했습니다.

## 검증
- npm run lint -- --file app/auth/login/LoginClient.tsx