### PR TITLE
fix: 이슈 #63 경매 종료시간 UTC 정규화

### DIFF
--- a/app/(web)/auctions/[id]/edit/EditAuctionClient.tsx
+++ b/app/(web)/auctions/[id]/edit/EditAuctionClient.tsx
@@ -60,6 +60,11 @@ const toDateTimeLocalValue = (value: string | Date) => {
   return local.toISOString().slice(0, 16);
 };
 
+const toIsoDateTimeValue = (value: string) => {
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? "" : date.toISOString();
+};
+
 const EditAuctionClient = () => {
   const params = useParams();
   const router = useRouter();
@@ -194,11 +199,17 @@ const EditAuctionClient = () => {
       toast.error("최소 1장의 사진을 등록해주세요.");
       return;
     }
+    const normalizedEndAt = toIsoDateTimeValue(form.endAt);
+    if (!normalizedEndAt) {
+      toast.error("유효한 종료 시간을 입력해주세요.");
+      return;
+    }
 
     updateAuction({
       data: {
         action: "update",
         ...form,
+        endAt: normalizedEndAt,
         category: selectedCategory,
         photos,
         sellerProofImage,


### PR DESCRIPTION
## 이슈
- https://github.com/ytw418/breeder_web/issues/63

## 변경 파일
- app/(web)/auctions/create/CreateAuctionClient.tsx
- app/(web)/auctions/[id]/edit/EditAuctionClient.tsx

## 검증
- npm run verify:ci: 실패 (`next: command not found`)

## 남은 위험/체크포인트
- 실제 배포 환경에서 `next` 의존성 설치 후 `npm run verify:ci` 전체 통과 확인 필요
- 기존 저장된 기존 경매 데이터(이미 잘못 저장된 endAt)는 별도 마이그레이션 대상

Closes #63
