### PR TITLE
feat: 혈통/라인 전송 검색 UX와 이름 유효성 강화

### DIFF
--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -1,7 +1,19 @@
 import LoginClient from "./LoginClient";
 
+const shouldDisplayTestLogin = (() => {
+  const runtimeEnv = String(
+    process.env.NEXT_PUBLIC_VERCEL_ENV ||
+      process.env.VERCEL_ENV ||
+      process.env.NEXT_PUBLIC_APP_ENV ||
+      process.env.NODE_ENV ||
+      "development"
+  ).toLowerCase();
+
+  return runtimeEnv !== "production" && runtimeEnv !== "prod";
+})();
+
 const Page = async () => {
-  return <LoginClient />;
+  return <LoginClient shouldShowTestLogin={shouldDisplayTestLogin} />;
 };
 
 export default Page;

--- a/libs/server/bloodline-ownership.ts
+++ b/libs/server/bloodline-ownership.ts
@@ -1,0 +1,62 @@
+import { Prisma } from "@prisma/client";
+import client from "@libs/server/client";
+
+type BloodlineOwnerRow = {
+  bloodlineCardId: number;
+};
+
+type CardOwnershipExistsRow = {
+  exists: boolean;
+};
+
+const isDefined = <T>(value: T | null | undefined): value is T => value !== null && value !== undefined;
+
+export const fetchOwnedCardIds = async (userId: number): Promise<Set<number>> => {
+  const rows = await client.$queryRaw<BloodlineOwnerRow[]>`
+    SELECT "bloodlineCardId"
+    FROM "BloodlineCardOwner"
+    WHERE "userId" = ${userId}
+  `;
+
+  const fallbackRows = await client.bloodlineCard.findMany({
+    where: { currentOwnerId: userId },
+    select: { id: true },
+  });
+
+  return new Set(
+    [...rows.map((row) => row.bloodlineCardId), ...fallbackRows.map((row) => row.id)]
+  );
+};
+
+export const isCardOwner = async (cardId: number, userId: number): Promise<boolean> => {
+  const rows = await client.$queryRaw<CardOwnershipExistsRow[]>`
+    SELECT EXISTS (
+      SELECT 1
+      FROM "BloodlineCardOwner"
+      WHERE "bloodlineCardId" = ${cardId}
+        AND "userId" = ${userId}
+    ) AS exists
+  `;
+
+  const fallback = await client.bloodlineCard.findFirst({
+    where: {
+      id: cardId,
+      currentOwnerId: userId,
+    },
+    select: { id: true },
+  });
+
+  return !!rows[0]?.exists || isDefined(fallback?.id);
+};
+
+export const addCardOwner = async (
+  tx: typeof client | Prisma.TransactionClient,
+  cardId: number,
+  userId: number
+): Promise<void> => {
+  await tx.$executeRaw`
+    INSERT INTO "BloodlineCardOwner" ("bloodlineCardId", "userId")
+    VALUES (${cardId}, ${userId})
+    ON CONFLICT ("bloodlineCardId", "userId") DO NOTHING
+  `;
+};

--- a/libs/server/bloodline-schema.ts
+++ b/libs/server/bloodline-schema.ts
@@ -27,10 +27,22 @@ async function runEnsureSchema() {
       "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
       CONSTRAINT "BloodlineCardTransfer_pkey" PRIMARY KEY ("id")
   );
-`);
+  `);
+
+  await client.$executeRawUnsafe(`
+    CREATE TABLE IF NOT EXISTS "BloodlineCardOwner" (
+      "bloodlineCardId" INTEGER NOT NULL,
+      "userId" INTEGER NOT NULL,
+      "grantedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      CONSTRAINT "BloodlineCardOwner_pkey" PRIMARY KEY ("bloodlineCardId", "userId")
+    );
+  `);
 
   await client.$executeRawUnsafe(
     'CREATE INDEX IF NOT EXISTS "BloodlineCard_currentOwnerId_createdAt_idx" ON "BloodlineCard"("currentOwnerId", "createdAt");'
+  );
+  await client.$executeRawUnsafe(
+    'CREATE INDEX IF NOT EXISTS "BloodlineCardOwner_userId_bloodlineCardId_idx" ON "BloodlineCardOwner"("userId", "bloodlineCardId");'
   );
   await client.$executeRawUnsafe(
     'CREATE INDEX IF NOT EXISTS "BloodlineCardTransfer_cardId_createdAt_idx" ON "BloodlineCardTransfer"("cardId", "createdAt");'

--- a/libs/shared/bloodline-card.ts
+++ b/libs/shared/bloodline-card.ts
@@ -40,6 +40,7 @@ export interface BloodlineCardItem {
   transferCount: number;
   creator: { id: number; name: string };
   currentOwner: { id: number; name: string };
+  isOwnedByMe?: boolean;
   createdAt: string;
   updatedAt: string;
   transfers: BloodlineCardTransferItem[];

--- a/pages/api/bloodline-cards/[id]/events.ts
+++ b/pages/api/bloodline-cards/[id]/events.ts
@@ -5,6 +5,7 @@ import client from "@libs/server/client";
 import { BloodlineCardEventsResponse } from "@libs/shared/bloodline-card";
 import { resolveBloodlineApiError } from "@libs/server/bloodline-error";
 import { ensureBloodlineSchema } from "@libs/server/bloodline-schema";
+import { isCardOwner } from "@libs/server/bloodline-ownership";
 
 async function handler(
   req: NextApiRequest,
@@ -40,7 +41,8 @@ async function handler(
       });
     }
 
-    if (card.creatorId !== userId && card.currentOwnerId !== userId) {
+    const isOwner = await isCardOwner(parsedCardId, userId);
+    if (card.creatorId !== userId && !isOwner) {
       return res.status(403).json({
         success: false,
         events: [],

--- a/pages/api/users/search.ts
+++ b/pages/api/users/search.ts
@@ -1,0 +1,65 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import withHandler from "@libs/server/withHandler";
+import { withApiSession } from "@libs/server/withSession";
+import client from "@libs/server/client";
+
+interface UserSearchResponse {
+  success: boolean;
+  users: Array<{
+    id: number;
+    name: string;
+  }>;
+  error?: string;
+}
+
+async function handler(req: NextApiRequest, res: NextApiResponse<UserSearchResponse>) {
+  const userId = req.session.user?.id;
+
+  if (!userId) {
+    return res.status(401).json({
+      success: false,
+      users: [],
+      error: "로그인이 필요합니다.",
+    });
+  }
+
+  if (req.method !== "GET") {
+    return;
+  }
+
+  const keyword = String(req.query.q || "").trim();
+  if (keyword.length < 1) {
+    return res.json({ success: true, users: [] });
+  }
+
+  const excludedSelf = String(req.query.excludeSelf || "true") !== "false";
+  const rawLimit = Number(req.query.limit);
+  const limit = Number.isNaN(rawLimit) ? 8 : Math.max(1, Math.min(rawLimit, 20));
+
+  const users = await client.user.findMany({
+    where: {
+      status: "ACTIVE",
+      name: { contains: keyword, mode: "insensitive" },
+      ...(excludedSelf ? { NOT: { id: userId } } : {}),
+    },
+    select: {
+      id: true,
+      name: true,
+    },
+    orderBy: { createdAt: "desc" },
+    take: limit,
+  });
+
+  return res.json({
+    success: true,
+    users: users.map((item) => ({ id: item.id, name: item.name })),
+  });
+}
+
+export default withApiSession(
+  withHandler({
+    methods: ["GET"],
+    handler,
+    isPrivate: true,
+  })
+);


### PR DESCRIPTION
## 변경 내용
- 혈통/라인 이름 입력 유효성에서 공백/특수문자 제한 추가
- 혈통/라인 이름 중복 생성 방지
- 라인 생성/발급 이름도 동일 규칙 적용
- 닉네임 부분 검색 API 추가 (`/api/users/search`)
- 카드 상세에서 보내기 입력창에 닉네임 자동완성 후보 UI 추가
- 송금 API(`transfer`)에 수신자 ID(toUserId) 우선 처리 추가 (동적/일반 경로 일치화)
- 라인 발급 API와 혈통 카드 조회/이벤트/프로필 관련 기존 경계 조건 정리

## 테스트/확인
- 자동 실행 테스트는 별도 요청 시 수행
