### PR TITLE
fix: 반려생활 탭 게시글 최신순 정렬 정렬 기준 보정

### DIFF
--- a/app/(web)/posts/PostsClient.tsx
+++ b/app/(web)/posts/PostsClient.tsx
@@ -419,7 +419,7 @@ export default function PostsClient() {
           )}
 
           {/* 결과 없을 때 */}
-          {data && prioritizedPosts.length === 0 && (
+          {data && orderedPosts.length === 0 && (
             <div className="px-4 py-8">
               <div className="mb-4 text-center">
                 <p className="app-title-md text-slate-600">


### PR DESCRIPTION
## 변경 요약\n- 반려생활 탭(전체/카테고리) 게시글 목록을 생성일 기준(desc)으로 통일\n- 카테고리 우선 노출 정렬 의존 로직 제거\n- 이슈 #71 대응: 최신순 정렬이 아닌 노출이 되던 문제 수정\n\n## 영향 범위\n- app/(web)/posts/PostsClient.tsx\n\n## 체크 항목\n- PR 리뷰/검증은 기존 워크플로우(quality, gate, Vercel)를 통해 확인