### PR TITLE
fake 계정 조회/전환 조건 보강

### DIFF
--- a/app/(web)/myPage/MyPageClient.tsx
+++ b/app/(web)/myPage/MyPageClient.tsx
@@ -220,10 +220,11 @@ const MyPageClient = () => {
   }, [bloodlineData, user?.id]);
 
   const isTestEnv = isTestEnvAvailable();
+  const isTestUser = user?.role === "FAKE_USER" || user?.provider === "test_user";
   const fakeUserListForSwitch = fakeUsers.filter((item) => item.id !== user?.id);
 
   useEffect(() => {
-    if (!isTestEnv || user?.role !== "FAKE_USER") return;
+    if (!isTestEnv || !isTestUser) return;
 
     let mounted = true;
     setFakeUsersLoading(true);
@@ -264,7 +265,7 @@ const MyPageClient = () => {
     return () => {
       mounted = false;
     };
-  }, [user?.role, isTestEnv]);
+  }, [isTestUser, isTestEnv]);
 
   const tabCountMap: Record<ActivityTab, number> = {
     posts: profileUser?._count?.posts ?? 0,
@@ -444,7 +445,7 @@ const MyPageClient = () => {
             로그아웃
           </Button>
         </div>
-        {user?.role === "FAKE_USER" ? (
+        {isTestUser ? (
           <div className="mt-4 rounded-lg border border-slate-200 bg-slate-50 p-3 dark:border-slate-700/80 dark:bg-slate-800/50">
             <p className="text-xs font-semibold text-slate-700">다른 FAKE_USER 전환</p>
             <p className="mt-1 text-[11px] text-slate-500">

--- a/pages/api/admin/users.ts
+++ b/pages/api/admin/users.ts
@@ -182,6 +182,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse<ResponseType>) 
             provider: "test_user",
             name: nickname,
             email: null,
+            role: "FAKE_USER",
           },
           select: {
             id: true,

--- a/pages/api/users/test-accounts.ts
+++ b/pages/api/users/test-accounts.ts
@@ -43,7 +43,10 @@ const isSwitchableTestUser = (targetUser?: {
   status?: UserStatus;
 } | null): boolean => {
   if (!targetUser) return false;
-  return targetUser.status === "ACTIVE" && targetUser.role === TEST_USER_ROLE;
+  return (
+    targetUser.status === "ACTIVE" &&
+    (targetUser.role === TEST_USER_ROLE || targetUser.provider === "test_user")
+  );
 };
 
 async function handler(
@@ -53,7 +56,7 @@ async function handler(
   if (req.method === "GET") {
     const users = await client.user.findMany({
       where: {
-        role: TEST_USER_ROLE,
+        OR: [{ role: TEST_USER_ROLE }, { provider: "test_user" }],
         status: "ACTIVE",
       },
       orderBy: [{ createdAt: "desc" }, { id: "desc" }],


### PR DESCRIPTION
## 변경 내용
- 테스트 계정 조회 API에서 FAKE 유저 판별 조건을 `role === FAKE_USER`뿐 아니라 `provider === test_user`까지 확대
- 테스트 계정 전환 가능 판별(`isSwitchableTestUser`)도 동일 조건으로 완화
- 관리자 생성 테스트 계정(`create_test_user`) 생성 시 `role: FAKE_USER` 저장
- 마이페이지 fake 유저 전환 UI 노출 및 목록 조회 조건을 `role` 또는 `provider` 기반으로 수정

## 확인 포인트
- 테스트 계정 목록이 role/provider 기준으로 모두 노출되는지
- 마이페이지에서 test_user 기반 fake 유저 전환 UI가 노출되는지