### PR TITLE
포스트/경매 상세 페이지 id-title SEO 경로 통일

### DIFF
--- a/app/(web)/(main)/MainClient.tsx
+++ b/app/(web)/(main)/MainClient.tsx
@@ -21,6 +21,8 @@ import { ANALYTICS_EVENTS, trackEvent } from "@libs/client/analytics";
 import { AuctionsListResponse } from "pages/api/auctions";
 import useUser from "hooks/useUser";
 import { RankingResponse } from "pages/api/ranking";
+import { toAuctionPath } from "@libs/auction-route";
+import { toPostPath } from "@libs/post-route";
 
 export interface ProductWithCount extends Product {
   _count: { favs: number };
@@ -364,7 +366,7 @@ const MainClient = () => {
                 hotPostsData.postRanking.slice(0, 5).map((post, index) => (
                   <Link
                     key={post.id}
-                    href={`/posts/${post.id}`}
+                    href={toPostPath(post.id, post.title)}
                     className="snap-start shrink-0 w-64 app-card app-card-interactive p-3"
                   >
                     <div className="flex items-start justify-between gap-2">
@@ -434,9 +436,9 @@ const MainClient = () => {
         <div className="app-rail mt-2 flex gap-3 pl-5 pr-4">
           {ongoingAuctionsData ? (
             ongoingAuctionsData.auctions.slice(0, 5).map((auction, index) => (
-              <Link
+                  <Link
                 key={auction.id}
-                href={`/auctions/${auction.id}`}
+                href={toAuctionPath(auction.id, auction.title)}
                 onClick={() =>
                   trackEvent(ANALYTICS_EVENTS.homeOngoingAuctionClicked, {
                     auction_id: auction.id,

--- a/app/(web)/auctions/AuctionsClient.tsx
+++ b/app/(web)/auctions/AuctionsClient.tsx
@@ -11,6 +11,7 @@ import { useInfiniteScroll } from "hooks/useInfiniteScroll";
 
 import { cn, makeImageUrl } from "@libs/client/utils";
 import { AuctionsListResponse } from "pages/api/auctions";
+import { toAuctionPath } from "@libs/auction-route";
 
 /** 상태 탭 */
 const STATUS_TABS = [
@@ -226,7 +227,7 @@ export default function AuctionsClient() {
                 result?.auctions?.map((auction) => (
                   <Link
                     key={auction.id}
-                    href={`/auctions/${auction.id}`}
+                    href={toAuctionPath(auction.id, auction.title)}
                     className="block overflow-hidden rounded-xl border border-slate-100 bg-white dark:border-slate-800 dark:bg-slate-900"
                   >
                     {/* 이미지 */}

--- a/app/(web)/auctions/[id]/edit/EditAuctionClient.tsx
+++ b/app/(web)/auctions/[id]/edit/EditAuctionClient.tsx
@@ -15,6 +15,7 @@ import { toast } from "react-toastify";
 import { AuctionDetailResponse } from "pages/api/auctions/[id]";
 import { AUCTION_MIN_START_PRICE, getBidIncrement } from "@libs/auctionRules";
 import { getAuctionErrorMessage } from "@libs/client/auctionErrorMessage";
+import { extractAuctionIdFromPath, toAuctionPath } from "@libs/auction-route";
 
 interface AuctionEditForm {
   title: string;
@@ -74,9 +75,10 @@ const EditAuctionClient = () => {
   const [proofUploading, setProofUploading] = useState(false);
   const [selectedCategory, setSelectedCategory] = useState("");
   const [selectedDuration, setSelectedDuration] = useState<number | null>(null);
+  const auctionId = params?.id ? extractAuctionIdFromPath(params.id) : Number.NaN;
 
   const { data } = useSWR<AuctionDetailResponse>(
-    params?.id ? `/api/auctions/${params.id}` : null
+    Number.isNaN(auctionId) ? null : `/api/auctions/${auctionId}`
   );
 
   const {
@@ -89,7 +91,7 @@ const EditAuctionClient = () => {
   } = useForm<AuctionEditForm>();
 
   const [updateAuction, { loading }] = useMutation<AuctionUpdateResponse>(
-    params?.id ? `/api/auctions/${params.id}` : ""
+    Number.isNaN(auctionId) ? "" : `/api/auctions/${auctionId}`
   );
 
   useEffect(() => {
@@ -222,7 +224,10 @@ const EditAuctionClient = () => {
           );
         }
         toast.success("경매가 수정되었습니다.");
-        router.push(`/auctions/${params?.id}`);
+        if (Number.isNaN(auctionId)) {
+          return router.push("/auctions");
+        }
+        router.push(toAuctionPath(auctionId, form.title));
       },
       onError() {
         toast.error("오류가 발생했습니다.");
@@ -263,7 +268,7 @@ const EditAuctionClient = () => {
             <Button
               type="button"
               className="mt-2"
-              onClick={() => router.push(`/auctions/${params?.id}`)}
+              onClick={() => router.push(Number.isNaN(auctionId) ? "/auctions" : toAuctionPath(auctionId, data?.auction?.title))}
             >
               상세로 돌아가기
             </Button>

--- a/app/(web)/auctions/create/CreateAuctionClient.tsx
+++ b/app/(web)/auctions/create/CreateAuctionClient.tsx
@@ -12,6 +12,7 @@ import { Textarea } from "@components/ui/textarea";
 import useMutation from "hooks/useMutation";
 import useUser from "hooks/useUser";
 import { cn, makeImageUrl } from "@libs/client/utils";
+import { toAuctionPath } from "@libs/auction-route";
 import { toast } from "react-toastify";
 import {
   AUCTION_EXTENSION_MS,
@@ -140,6 +141,7 @@ const CreateAuctionClient = () => {
   const [agreedDisputePolicy, setAgreedDisputePolicy] = useState(false);
   const [shareModalOpen, setShareModalOpen] = useState(false);
   const [createdAuctionId, setCreatedAuctionId] = useState<number | null>(null);
+  const [createdAuctionTitle, setCreatedAuctionTitle] = useState<string>("");
   const [lastCreatedSignature, setLastCreatedSignature] = useState<string | null>(null);
   const [confirmModalOpen, setConfirmModalOpen] = useState(false);
   const [pendingSubmission, setPendingSubmission] =
@@ -439,6 +441,7 @@ const CreateAuctionClient = () => {
         if (result.success && result.auction?.id) {
           setLastCreatedSignature(refreshedSignature);
           setCreatedAuctionId(result.auction.id);
+          setCreatedAuctionTitle(result.auction.title || "");
           setConfirmModalOpen(false);
           setPendingSubmission(null);
           setShareModalOpen(true);
@@ -459,7 +462,9 @@ const CreateAuctionClient = () => {
   };
 
   const getCreatedAuctionPath = () =>
-    createdAuctionId ? withBasePath(`/auctions/${createdAuctionId}`) : "";
+    createdAuctionId
+      ? withBasePath(toAuctionPath(createdAuctionId, createdAuctionTitle))
+      : "";
 
   const getCreatedAuctionUrl = () => {
     const path = getCreatedAuctionPath();

--- a/app/(web)/auctions/page.tsx
+++ b/app/(web)/auctions/page.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from "next";
 import AuctionsClient from "./AuctionsClient";
 import Script from "next/script";
 import client from "@libs/server/client";
+import { toAuctionPath } from "@libs/auction-route";
 
 const AUCTION_OG_IMAGE = "/designer/og/bredy-og-auction.png";
 const SITE_URL = "https://bredy.app";
@@ -80,7 +81,7 @@ const page = async () => {
     itemListElement: auctions.map((auction, index) => ({
       "@type": "ListItem",
       position: index + 1,
-      url: `${SITE_URL}/auctions/${auction.id}`,
+      url: `${SITE_URL}${toAuctionPath(auction.id, auction.title)}`,
       name: auction.title,
     })),
   };

--- a/app/(web)/notifications/NotificationsClient.tsx
+++ b/app/(web)/notifications/NotificationsClient.tsx
@@ -12,6 +12,8 @@ import { NotificationsResponse } from "pages/api/notifications";
 import { NotificationType } from "@prisma/client";
 import { usePathname } from "next/navigation";
 import { getProductPath } from "@libs/product-route";
+import { toPostPath } from "@libs/post-route";
+import { toAuctionPath } from "@libs/auction-route";
 
 /** 알림 타입별 색상 */
 const NOTIFICATION_COLORS: Record<NotificationType, string> = {
@@ -38,7 +40,7 @@ const getNotificationLink = (
 
   switch (targetType) {
     case "post":
-      return `/posts/${targetId}`;
+      return toPostPath(targetId);
     case "product":
       return getProductPath(targetId);
     case "chatRoom":
@@ -46,7 +48,7 @@ const getNotificationLink = (
     case "user":
       return `/profiles/${targetId}`;
     case "auction":
-      return `/auctions/${targetId}`;
+      return toAuctionPath(targetId);
     case "record":
       return `/guinness`;
     case "guinness_submission":
@@ -106,7 +108,7 @@ const NotificationsClient = () => {
     if (!targetType || !targetId) return "/tool";
 
     if (targetType === "auction") {
-      return `/tool/auctions/${targetId}`;
+      return `/tool${toAuctionPath(targetId)}`;
     }
 
     return "/tool";

--- a/app/(web)/posts/PostsClient.tsx
+++ b/app/(web)/posts/PostsClient.tsx
@@ -11,6 +11,7 @@ import useSWRInfinite from "swr/infinite";
 import { useInfiniteScroll } from "hooks/useInfiniteScroll";
 
 import { cn, getTimeAgoString, makeImageUrl } from "@libs/client/utils";
+import { toPostPath } from "@libs/post-route";
 import { POST_CATEGORIES } from "@libs/constants";
 import { PostsListResponse } from "pages/api/posts";
 import { NoticePostsResponse } from "pages/api/posts/notices";
@@ -138,7 +139,7 @@ export default function PostsClient() {
           id: `notice-${post.id}`,
           label: "공지",
           title: post.title,
-          href: `/posts/${post.id}`,
+          href: toPostPath(post.id, post.title),
         }))
       : NOTICE_BANNERS.map((notice) => ({
           id: notice.id,
@@ -330,7 +331,7 @@ export default function PostsClient() {
             sortedPosts.map((post) => (
                 <Link
                   key={post.id}
-                  href={`/posts/${post.id}`}
+                  href={toPostPath(post.id, post.title)}
                   className="block w-full border-b border-slate-100 px-4 py-3 transition-colors hover:bg-slate-50"
                 >
                   <div className="flex items-start gap-2.5">

--- a/app/(web)/posts/[id]/PostClient.tsx
+++ b/app/(web)/posts/[id]/PostClient.tsx
@@ -13,6 +13,7 @@ import { useParams, useRouter } from "next/navigation";
 import { useForm } from "react-hook-form";
 
 import { PostDetailResponse } from "pages/api/posts/[id]";
+import { extractPostIdFromPath, toPostPath } from "@libs/post-route";
 import { toast } from "react-toastify";
 
 interface CommentForm {
@@ -25,22 +26,24 @@ const PostClient = ({
   nextNotice: initialNextNotice,
 }: PostDetailResponse) => {
   const query = useParams();
+  const postId = extractPostIdFromPath(query?.id);
+  const postApiId = Number.isNaN(postId) ? null : postId;
   const router = useRouter();
   const { user } = useUser();
 
   // 실시간 데이터 페칭
   const { data, mutate: boundMutate } = useSWR<PostDetailResponse>(
-    query?.id ? `/api/posts/${query.id}` : null
+    postApiId ? `/api/posts/${postApiId}` : null
   );
 
   // 좋아요 토글 API
   const [toggleLike, { loading: likeLoading }] = useMutation(
-    query?.id ? `/api/posts/${query?.id}/wonder` : ""
+    postApiId ? `/api/posts/${postApiId}/wonder` : ""
   );
 
   // 댓글 작성 API
   const [postComment, { loading: commentLoading }] = useMutation(
-    query?.id ? `/api/posts/${query?.id}/answers` : ""
+    postApiId ? `/api/posts/${postApiId}/answers` : ""
   );
 
   const { register, handleSubmit, reset } = useForm<CommentForm>();
@@ -204,11 +207,11 @@ const PostClient = ({
           <section className="border-b border-slate-100 bg-slate-50 px-4 py-3">
             <h2 className="text-sm font-semibold text-slate-700">다른 공지 보기</h2>
             <div className="mt-2 overflow-hidden rounded-lg border border-slate-200 bg-white">
-              {prevNotice ? (
-                <Link
-                  href={`/posts/${prevNotice.id}`}
-                  className="flex items-center gap-2 border-b border-slate-100 px-3 py-2.5 hover:bg-slate-50"
-                >
+	              {prevNotice ? (
+	                <Link
+	                  href={toPostPath(prevNotice.id, prevNotice.title)}
+	                  className="flex items-center gap-2 border-b border-slate-100 px-3 py-2.5 hover:bg-slate-50"
+	                >
                   <span className="shrink-0 text-xs font-semibold text-slate-500">
                     이전 공지
                   </span>
@@ -225,11 +228,11 @@ const PostClient = ({
                 </div>
               )}
 
-              {nextNotice ? (
-                <Link
-                  href={`/posts/${nextNotice.id}`}
-                  className="flex items-center gap-2 px-3 py-2.5 hover:bg-slate-50"
-                >
+	              {nextNotice ? (
+	                <Link
+	                  href={toPostPath(nextNotice.id, nextNotice.title)}
+	                  className="flex items-center gap-2 px-3 py-2.5 hover:bg-slate-50"
+	                >
                   <span className="shrink-0 text-xs font-semibold text-slate-500">
                     다음 공지
                   </span>

--- a/app/(web)/posts/notices/NoticePostsClient.tsx
+++ b/app/(web)/posts/notices/NoticePostsClient.tsx
@@ -8,6 +8,7 @@ import Image from "@components/atoms/Image";
 import Layout from "@components/features/MainLayout";
 import { useInfiniteScroll } from "hooks/useInfiniteScroll";
 import { getTimeAgoString, makeImageUrl } from "@libs/client/utils";
+import { toPostPath } from "@libs/post-route";
 import { NoticePostsResponse } from "pages/api/posts/notices";
 
 const PAGE_SIZE = 10;
@@ -52,7 +53,7 @@ export default function NoticePostsClient() {
               notices.map((post) => (
                 <Link
                   key={post.id}
-                  href={`/posts/${post.id}`}
+                  href={toPostPath(post.id, post.title)}
                   className="block w-full border-b border-slate-100 px-4 py-3 transition-colors hover:bg-slate-50"
                 >
                   <div className="flex items-start gap-2.5">

--- a/app/(web)/posts/upload/UploadClient.tsx
+++ b/app/(web)/posts/upload/UploadClient.tsx
@@ -13,6 +13,7 @@ import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { cn } from "@libs/client/utils";
 import { POST_CATEGORIES } from "@libs/constants";
+import { toPostPath } from "@libs/post-route";
 import { toast } from "react-toastify";
 
 interface UploadPostForm {
@@ -111,7 +112,7 @@ const UploadClient = () => {
 
       if (result.success && result.post?.id) {
         toast.success("게시글이 등록되었습니다.");
-        router.push(`/posts/${result.post.id}`);
+        router.push(toPostPath(result.post.id, result.post.title));
         return;
       }
 

--- a/app/(web)/ranking/RankingClient.tsx
+++ b/app/(web)/ranking/RankingClient.tsx
@@ -8,6 +8,7 @@ import Layout from "@components/features/MainLayout";
 import { cn, makeImageUrl } from "@libs/client/utils";
 import { RankingResponse, BredyRank } from "pages/api/ranking";
 import { useRouter } from "next/navigation";
+import { toPostPath } from "@libs/post-route";
 
 /** 메인 탭 */
 const TABS = [
@@ -300,7 +301,7 @@ const PostRankingContent = ({ posts }: { posts: RankingResponse["postRanking"] }
           {posts.slice(0, 3).map((post, i) => (
             <Link
               key={post.id}
-              href={`/posts/${post.id}`}
+              href={toPostPath(post.id, post.title)}
               className="relative overflow-hidden rounded-xl aspect-square app-card-interactive"
             >
               {post.image && (
@@ -340,7 +341,7 @@ const PostRankingContent = ({ posts }: { posts: RankingResponse["postRanking"] }
         return (
           <Link
             key={post.id}
-            href={`/posts/${post.id}`}
+            href={toPostPath(post.id, post.title)}
             className="app-card app-card-interactive flex items-center gap-3 p-3 transition-colors hover:bg-slate-50"
           >
             <div

--- a/app/(web)/search/SearchClient.tsx
+++ b/app/(web)/search/SearchClient.tsx
@@ -9,6 +9,7 @@ import Link from "next/link";
 import { SearchResponse } from "pages/api/search";
 import { CATEGORIES } from "@libs/constants";
 import { getProductPath } from "@libs/product-route";
+import { toPostPath } from "@libs/post-route";
 
 type SearchTab = "all" | "products" | "posts" | "users";
 
@@ -329,12 +330,12 @@ const SearchClient = () => {
                 </Link>
               </div>
               <div className="divide-y divide-gray-50 dark:divide-slate-800">
-                {recommendPosts.posts.slice(0, 5).map((post) => (
-                  <Link
-                    key={post.id}
-                    href={`/posts/${post.id}`}
-                    className="flex items-center gap-4 px-4 py-3 hover:bg-gray-50 dark:hover:bg-slate-800/70 transition-colors"
-                  >
+                  {recommendPosts.posts.slice(0, 5).map((post) => (
+                    <Link
+                      key={post.id}
+                      href={toPostPath(post.id, post.title)}
+                      className="flex items-center gap-4 px-4 py-3 hover:bg-gray-50 dark:hover:bg-slate-800/70 transition-colors"
+                    >
                     <div className="flex-1 min-w-0">
                       <p className="text-sm font-medium text-gray-900 dark:text-slate-100 truncate">
                         {post.title}
@@ -485,7 +486,7 @@ const SearchClient = () => {
                   {data.posts.map((post) => (
                     <Link
                       key={post.id}
-                      href={`/posts/${post.id}`}
+                      href={toPostPath(post.id, post.title)}
                       className="flex items-center gap-4 px-4 py-3 hover:bg-gray-50 dark:hover:bg-slate-800/70 transition-colors"
                     >
                       <div className="flex-1 min-w-0">

--- a/app/(web)/tool/auctions/[id]/page.tsx
+++ b/app/(web)/tool/auctions/[id]/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import AuctionDetailClient from "../../../auctions/[id]/AuctionDetailClient";
+import { extractAuctionIdFromPath, toAuctionPath } from "@libs/auction-route";
 
 interface Props {
   params: {
@@ -8,6 +9,11 @@ interface Props {
 }
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const auctionId = extractAuctionIdFromPath(params.id);
+  const canonical = Number.isNaN(auctionId)
+    ? "https://bredy.app/auctions"
+    : `https://bredy.app${toAuctionPath(auctionId)}`;
+
   return {
     title: `경매 상세 | 경매 폼 생성기`,
     description: "경매 상세 확인 및 입찰 화면입니다.",
@@ -16,7 +22,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       follow: false,
     },
     alternates: {
-      canonical: `https://bredy.app/auctions/${params.id}`,
+      canonical,
     },
   };
 }

--- a/app/admin/auctions/page.tsx
+++ b/app/admin/auctions/page.tsx
@@ -7,6 +7,7 @@ import { toast } from "react-toastify";
 import { Button } from "@components/ui/button";
 import { Input } from "@components/ui/input";
 import useConfirmDialog from "hooks/useConfirmDialog";
+import { toAuctionPath } from "@libs/auction-route";
 import {
   AUCTION_EDIT_WINDOW_MS,
   AUCTION_EXTENSION_MS,
@@ -480,7 +481,7 @@ export default function AdminAuctionsPage() {
                 <tr key={auction.id}>
                   <td className="px-6 py-4">
                     <Link
-                      href={`/auctions/${auction.id}`}
+                      href={toAuctionPath(auction.id, auction.title)}
                       target="_blank"
                       className="inline-flex max-w-full text-sm font-semibold text-gray-900 underline-offset-2 hover:underline"
                     >

--- a/app/admin/posts/page.tsx
+++ b/app/admin/posts/page.tsx
@@ -8,6 +8,7 @@ import { Button } from "@components/ui/button";
 import { Input } from "@components/ui/input";
 import { Textarea } from "@components/ui/textarea";
 import useConfirmDialog from "hooks/useConfirmDialog";
+import { toPostPath } from "@libs/post-route";
 
 export default function AdminPostsPage() {
   const [page, setPage] = useState(1);
@@ -154,13 +155,13 @@ export default function AdminPostsPage() {
                         </span>
                       )}
                       <div className="text-sm font-medium text-gray-900 line-clamp-1">
-                        <Link href={`/posts/${post.id}`} target="_blank" className="hover:underline">
+                        <Link href={toPostPath(post.id, post.title)} target="_blank" className="hover:underline">
                           {post.title}
                         </Link>
                       </div>
                     </div>
                     <div className="text-sm text-gray-500 line-clamp-1 mt-1">
-                      <Link href={`/posts/${post.id}`} target="_blank" className="hover:underline">
+                      <Link href={toPostPath(post.id, post.title)} target="_blank" className="hover:underline">
                         {post.description}
                       </Link>
                     </div>

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,6 +1,8 @@
 import { MetadataRoute } from "next";
 import client from "@libs/server/client";
 import { getProductPath } from "@libs/product-route";
+import { toAuctionPath } from "@libs/auction-route";
+import { toPostPath } from "@libs/post-route";
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   // 정적 페이지 URL
@@ -85,6 +87,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     const auctions = await client.auction.findMany({
       select: {
         id: true,
+        title: true,
         updatedAt: true,
       },
       where: {
@@ -96,7 +99,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     });
 
     const auctionPages: MetadataRoute.Sitemap = auctions.map((auction) => ({
-      url: `https://bredy.app/auctions/${auction.id}`,
+      url: `https://bredy.app${toAuctionPath(auction.id, auction.title)}`,
       lastModified: auction.updatedAt,
       changeFrequency: "hourly",
       priority: 0.85,
@@ -105,6 +108,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     const posts = await client.post.findMany({
       select: {
         id: true,
+        title: true,
         updatedAt: true,
       },
       orderBy: {
@@ -114,7 +118,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     });
 
     const postPages: MetadataRoute.Sitemap = posts.map((post) => ({
-      url: `https://bredy.app/posts/${post.id}`,
+      url: `https://bredy.app${toPostPath(post.id, post.title)}`,
       lastModified: post.updatedAt,
       changeFrequency: "weekly",
       priority: 0.65,

--- a/libs/auction-route.ts
+++ b/libs/auction-route.ts
@@ -1,0 +1,44 @@
+const MAX_SLUG_LENGTH = 80;
+
+const normalizeTitleForSlug = (title: string) =>
+  title
+    .trim()
+    .replace(/[\\/]+/g, " ")
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/[^0-9A-Za-z가-힣._~-]/g, "")
+    .slice(0, MAX_SLUG_LENGTH)
+    .replace(/^-+|-+$/g, "");
+
+const normalizePathParam = (
+  pathParam: string | string[] | undefined
+): string => {
+  const value = Array.isArray(pathParam) ? pathParam[0] : pathParam;
+  return String(value ?? "").trim();
+};
+
+export const slugifyAuctionTitle = (title: string) => normalizeTitleForSlug(title);
+
+export const toAuctionPath = (
+  id: number | string,
+  title?: string | null
+): string => {
+  const safeId = String(id).trim();
+  if (!safeId) return "/auctions";
+
+  const slug = title ? normalizeTitleForSlug(title) : "";
+  if (!slug) return `/auctions/${safeId}`;
+
+  return `/auctions/${safeId}-${slug}`;
+};
+
+export const extractAuctionIdFromPath = (
+  pathParam: string | string[] | undefined
+): number => {
+  const path = normalizePathParam(pathParam);
+  if (!path) return Number.NaN;
+
+  const idOnly = path.split("-", 1)[0];
+  const id = Number(idOnly);
+  return Number.isNaN(id) ? Number.NaN : id;
+};

--- a/libs/post-route.ts
+++ b/libs/post-route.ts
@@ -1,0 +1,44 @@
+const MAX_SLUG_LENGTH = 80;
+
+const normalizeTitleForSlug = (title: string) =>
+  title
+    .trim()
+    .replace(/[\\/]+/g, " ")
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/[^0-9A-Za-z가-힣._~-]/g, "")
+    .slice(0, MAX_SLUG_LENGTH)
+    .replace(/^-+|-+$/g, "");
+
+const normalizePathParam = (
+  pathParam: string | string[] | undefined
+): string => {
+  const value = Array.isArray(pathParam) ? pathParam[0] : pathParam;
+  return String(value ?? "").trim();
+};
+
+export const slugifyPostTitle = (title: string) => normalizeTitleForSlug(title);
+
+export const toPostPath = (
+  id: number | string,
+  title?: string | null
+): string => {
+  const safeId = String(id).trim();
+  if (!safeId) return "/posts";
+
+  const slug = title ? normalizeTitleForSlug(title) : "";
+  if (!slug) return `/posts/${safeId}`;
+
+  return `/posts/${safeId}-${slug}`;
+};
+
+export const extractPostIdFromPath = (
+  pathParam: string | string[] | undefined
+): number => {
+  const path = normalizePathParam(pathParam);
+  if (!path) return Number.NaN;
+
+  const idOnly = path.split("-", 1)[0];
+  const id = Number(idOnly);
+  return Number.isNaN(id) ? Number.NaN : id;
+};

--- a/pages/api/auctions/[id]/bid.ts
+++ b/pages/api/auctions/[id]/bid.ts
@@ -10,6 +10,7 @@ import {
   getBidIncrement,
 } from "@libs/auctionRules";
 import { settleExpiredAuctions } from "@libs/server/auctionSettlement";
+import { extractAuctionIdFromPath } from "@libs/auction-route";
 
 /** 입찰 응답 타입 */
 export interface BidResponse {
@@ -38,7 +39,7 @@ async function handler(
     });
   }
 
-  const auctionId = Number(id);
+  const auctionId = extractAuctionIdFromPath(id);
   const bidAmount = Number(amount);
 
   if (isNaN(auctionId) || isNaN(bidAmount)) {

--- a/pages/api/auctions/[id]/index.ts
+++ b/pages/api/auctions/[id]/index.ts
@@ -3,6 +3,7 @@ import withHandler, { ResponseType } from "@libs/server/withHandler";
 import client from "@libs/server/client";
 import { withApiSession } from "@libs/server/withSession";
 import { Auction, Bid, User } from "@prisma/client";
+import { extractAuctionIdFromPath } from "@libs/auction-route";
 import {
   AUCTION_HIGH_PRICE_REQUIRE_CONTACT,
   AUCTION_MIN_START_PRICE,
@@ -53,7 +54,7 @@ async function handler(
     session: { user },
   } = req;
 
-  const auctionId = Number(id);
+  const auctionId = extractAuctionIdFromPath(id);
   if (isNaN(auctionId)) {
     return res.status(400).json({
       success: false,

--- a/pages/api/auctions/[id]/report.ts
+++ b/pages/api/auctions/[id]/report.ts
@@ -2,6 +2,7 @@ import { NextApiRequest, NextApiResponse } from "next";
 import withHandler, { ResponseType } from "@libs/server/withHandler";
 import { withApiSession } from "@libs/server/withSession";
 import client from "@libs/server/client";
+import { extractAuctionIdFromPath } from "@libs/auction-route";
 
 const REPORT_REASONS = [
   "허위 매물 의심",
@@ -34,7 +35,7 @@ async function handler(
     });
   }
 
-  const auctionId = Number(req.query.id);
+  const auctionId = extractAuctionIdFromPath(req.query.id);
   if (Number.isNaN(auctionId)) {
     return res.status(400).json({
       success: false,

--- a/pages/api/posts/[id]/answers.ts
+++ b/pages/api/posts/[id]/answers.ts
@@ -2,6 +2,7 @@ import { NextApiRequest, NextApiResponse } from "next";
 import withHandler, { ResponseType } from "@libs/server/withHandler";
 
 import client from "@libs/server/client";
+import { extractPostIdFromPath } from "@libs/post-route";
 import { withApiSession } from "@libs/server/withSession";
 import { createNotification } from "@libs/server/notification";
 
@@ -15,7 +16,10 @@ async function handler(
     body: { comment },
   } = req;
 
-  const postId = +id.toString();
+  const postId = extractPostIdFromPath(id);
+  if (Number.isNaN(postId)) {
+    return res.status(400).json({ success: false, error: "유효하지 않은 게시글 ID입니다." });
+  }
 
   const newAnswer = await client.comment.create({
     data: {

--- a/pages/api/posts/[id]/index.ts
+++ b/pages/api/posts/[id]/index.ts
@@ -2,6 +2,7 @@ import { NextApiRequest, NextApiResponse } from "next";
 import withHandler, { ResponseType } from "@libs/server/withHandler";
 
 import client from "@libs/server/client";
+import { extractPostIdFromPath } from "@libs/post-route";
 import { withApiSession } from "@libs/server/withSession";
 
 interface PostDetail {
@@ -57,10 +58,14 @@ async function handler(
     query: { id = "" },
     session: { user },
   } = req;
+  const postId = extractPostIdFromPath(id);
+  if (Number.isNaN(postId)) {
+    return res.status(400).json({ success: false, error: "유효하지 않은 게시글 ID입니다." });
+  }
 
   const post = await client.post.findUnique({
     where: {
-      id: +id.toString(),
+      id: postId,
     },
     include: {
       user: {
@@ -161,7 +166,7 @@ async function handler(
   const isLiked = Boolean(
     await client.like.findFirst({
       where: {
-        postId: +id.toString(),
+        postId,
         userId: user?.id,
       },
       select: {

--- a/pages/api/posts/[id]/wonder.ts
+++ b/pages/api/posts/[id]/wonder.ts
@@ -2,6 +2,7 @@ import { NextApiRequest, NextApiResponse } from "next";
 import withHandler, { ResponseType } from "@libs/server/withHandler";
 
 import client from "@libs/server/client";
+import { extractPostIdFromPath } from "@libs/post-route";
 import { withApiSession } from "@libs/server/withSession";
 import { createNotification } from "@libs/server/notification";
 
@@ -13,7 +14,10 @@ async function handler(
     query: { id = "" },
     session: { user },
   } = req;
-  const postId = +id.toString();
+  const postId = extractPostIdFromPath(id);
+  if (Number.isNaN(postId)) {
+    return res.status(400).json({ success: false, error: "유효하지 않은 게시글 ID입니다." });
+  }
 
   const alreadyExists = await client.like.findFirst({
     where: {


### PR DESCRIPTION
## 변경 내용
- 포스트 상세 페이지(`/posts/:id`)를 `/posts/:id-title` 형태로 정식 표시
- 경매 상세 페이지(`/auctions/:id`)를 `/auctions/:id-title` 형태로 정식 표시
- 기존 `id` 단독 URL은 하위 호환성 유지(접근 허용)
- `libs/post-route.ts`, `libs/auction-route.ts` 유틸 추가
- 상세/목록/알림/생성/수정/리디렉션 관련 링크를 slug 기반으로 통일
- sitemap 및 API 경로 파라미터 파싱을 `id-title` 허용 규약으로 변경

## 주요 반영 파일
- 상세 페이지: `app/(web)/posts/[id]/page.tsx`, `app/(web)/auctions/[id]/page.tsx`
- 라우팅 유틸: `libs/post-route.ts`, `libs/auction-route.ts`
- 링크 갱신: posts/auctions 목록/검색/랭킹/알림/관리자 화면 및 업로드/생성/수정 플로우
- API: `pages/api/posts/[id]/*`, `pages/api/auctions/[id]/*`
- SEO: `app/sitemap.ts`
