### PR TITLE
이미지 라이트박스 버그 수정 및 QA 안정화

### DIFF
--- a/app/(web)/products/[id]/ProductClient.tsx
+++ b/app/(web)/products/[id]/ProductClient.tsx
@@ -97,6 +97,10 @@ const ProductClient = ({ product, relatedProducts }: ItemDetailResponse) => {
   const handleTouchEnd = () => {
     const startX = touchStartX.current;
     const endX = touchEndX.current;
+
+    touchStartX.current = null;
+    touchEndX.current = null;
+
     if (startX === null || endX === null) return;
 
     const distance = startX - endX;
@@ -110,8 +114,6 @@ const ProductClient = ({ product, relatedProducts }: ItemDetailResponse) => {
       isImageDragging.current = false;
     }
 
-    touchStartX.current = null;
-    touchEndX.current = null;
   };
 
   /**

--- a/components/features/image/ImageLightbox.tsx
+++ b/components/features/image/ImageLightbox.tsx
@@ -39,14 +39,15 @@ const ImageLightbox = ({
   const handleTouchEnd = () => {
     const startX = touchStartX.current;
     const endX = touchEndX.current;
+
+    touchStartX.current = null;
+    touchEndX.current = null;
+
     if (startX === null || endX === null || images.length <= 1) return;
 
     const distance = startX - endX;
     if (distance > 50) onIndexChange((safeIndex + 1) % images.length);
     if (distance < -50) onIndexChange((safeIndex - 1 + images.length) % images.length);
-
-    touchStartX.current = null;
-    touchEndX.current = null;
   };
   useEffect(() => {
     if (!isOpen) return;


### PR DESCRIPTION
### Motivation
- 라이트박스에서 전달된 `currentIndex`가 이미지 배열 길이 변경으로 인해 out-of-range가 될 수 있고, 모바일에서 스와이프 후 발생하는 클릭으로 라이트박스가 의도치 않게 열리는 문제가 있어 안정화가 필요했습니다.

### Description
- `ImageLightbox`에 인덱스 정규화(`safeIndex`) 로직을 추가해 배열 길이 변화에도 안전하게 이미지가 표시되도록 했습니다.
- 키보드(ArrowLeft/ArrowRight) 이동과 라이트박스 내부 네비게이션 버튼을 `safeIndex` 기준으로 동작하도록 보완했습니다.
- 상품/경매 상세(`ProductClient`, `AuctionDetailClient`)에 이미지 배열 길이 변경 시 현재 인덱스를 자동으로 클램프하는 `useEffect`를 추가해 out-of-range를 방지했습니다.
- 모바일에서 드래그 도중 발생하는 불필요한 `click`으로 라이트박스가 열리는 현상을 막기 위해 드래그 감지용 `isImageDragging`를 도입하고 터치 이벤트 핸들러 및 클릭 열기 로직을 변경했으며, 네비게이션/인디케이터 버튼에 `stopPropagation`을 적용했습니다.

### Testing
- `npm run verify:ci` (lint + typecheck + test) 를 실행해 전체 자동화 검사와 테스트가 통과했습니다.
- 로컬 dev 서버에서 상세 페이지 흐름을 띄우고 Playwright 스크립트로 라이트박스 열기 동작을 캡처해 스크린샷을 확인했습니다(스크린샷 생성 성공).
- 개발 서버 실행 중 Google Fonts(`Inter`) 다운로드 실패 경고가 로그에 표시되었으나 폰트는 폴백으로 대체되어 기능에는 영향이 없음을 확인했습니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997214c85008322b3d66c8ddc08c77e)