### PR TITLE
혈통 랭킹 기준 단순화 및 홈 랭킹 UI 조정

### DIFF
--- a/app/(web)/(main)/MainClient.tsx
+++ b/app/(web)/(main)/MainClient.tsx
@@ -248,7 +248,7 @@ const MainClient = () => {
   const communityPeriod = homeFeedData?.trendingPostsMode === "all" ? "all" : "weekly";
   const heroSubtitle = "게시, 댓글, 입찰, 낙찰 활동을 합산한 브리더 리더보드";
   const auctionSubtitle = "카테고리별 최고 낙찰가를 기록한 경매";
-  const bloodlineSubtitle = "팔로우, 거래 수, 평균 낙찰가를 반영한 혈통 랭킹";
+  const bloodlineSubtitle = "가장 많은 사용자가 보유한 혈통카드를 기준으로 집계한 랭킹";
   const communitySubtitle = "좋아요와 댓글 반응이 높은 커뮤니티 글";
 
   return (
@@ -513,10 +513,8 @@ const MainClient = () => {
                     </div>
                   </div>
                   <div className="mt-3 grid grid-cols-2 gap-2 text-[11px] text-slate-600">
-                    <div className="rounded-2xl bg-slate-50 px-3 py-2">팔로우 {bloodline.followCount}</div>
-                    <div className="rounded-2xl bg-slate-50 px-3 py-2">거래 {bloodline.tradeCount}</div>
-                    <div className="rounded-2xl bg-slate-50 px-3 py-2">평균가 {bloodline.avgClosingPrice.toLocaleString()}원</div>
-                    <div className="rounded-2xl bg-slate-50 px-3 py-2">상승률 {formatGrowthRate(bloodline.growthRate7d)}</div>
+                    <div className="rounded-2xl bg-slate-50 px-3 py-2">보유자 {bloodline.ownerCount}</div>
+                    <div className="rounded-2xl bg-slate-50 px-3 py-2">발급 수 {bloodline.issuedCount}</div>
                   </div>
                 </Link>
               ))

--- a/app/(web)/ranking/RankingClient.tsx
+++ b/app/(web)/ranking/RankingClient.tsx
@@ -21,7 +21,7 @@ import {
 const RANKING_TABS = [
   { id: "breeders", label: "브리더", description: "게시, 댓글, 입찰, 낙찰 활동 점수" },
   { id: "auctions", label: "최고가 경매", description: "카테고리별 최고 낙찰 기록" },
-  { id: "bloodlines", label: "인기 혈통", description: "팔로우, 거래 수, 평균 낙찰가 기반" },
+  { id: "bloodlines", label: "인기 혈통", description: "보유자 수와 발급 수 기반" },
   { id: "community", label: "커뮤니티", description: "좋아요와 댓글 반응이 높은 글" },
 ] as const;
 
@@ -50,9 +50,6 @@ const formatRankDelta = (rankDelta: number) => {
   if (rankDelta < 0) return `▼ ${Math.abs(rankDelta)}`;
   return "유지";
 };
-
-const formatGrowthRate = (growthRate: number) =>
-  `${growthRate >= 0 ? "+" : ""}${Math.round(growthRate * 100)}%`;
 
 const getSummary = (tab: RankingTab, period: RankingPeriod) => {
   const periodLabel = period === "weekly" ? "이번 주" : "역대";
@@ -86,8 +83,8 @@ const getSummary = (tab: RankingTab, period: RankingPeriod) => {
       title: `${periodLabel} 인기 혈통`,
       description:
         period === "weekly"
-          ? "이번 주 거래 수, 평균 낙찰가, 팔로우 수, 직전 주 대비 상승률을 반영합니다."
-          : "누적 거래와 팔로우를 기준으로 인기 혈통을 정렬합니다.",
+          ? "실제 보유자 수가 많은 혈통카드를 우선으로 보여줍니다."
+          : "실제 보유자 수와 총 발급 수를 기준으로 인기 혈통을 정렬합니다.",
       ctaHref: "/bloodline-cards/create",
       ctaLabel: "혈통카드 만들기",
     };
@@ -332,10 +329,8 @@ const RankingClient = () => {
                       </div>
                     </div>
                     <div className="mt-3 grid grid-cols-2 gap-2 text-[11px] text-slate-600">
-                      <div className="rounded-2xl bg-slate-50 px-3 py-2">팔로우 {item.followCount}</div>
-                      <div className="rounded-2xl bg-slate-50 px-3 py-2">거래 {item.tradeCount}</div>
-                      <div className="rounded-2xl bg-slate-50 px-3 py-2">평균가 {item.avgClosingPrice.toLocaleString()}원</div>
-                      <div className="rounded-2xl bg-slate-50 px-3 py-2">상승률 {formatGrowthRate(item.growthRate7d)}</div>
+                      <div className="rounded-2xl bg-slate-50 px-3 py-2">보유자 {item.ownerCount}</div>
+                      <div className="rounded-2xl bg-slate-50 px-3 py-2">발급 수 {item.issuedCount}</div>
                     </div>
                   </Link>
                 ))}

--- a/libs/server/ranking.ts
+++ b/libs/server/ranking.ts
@@ -454,18 +454,15 @@ export const getAuctionRanking = async ({
 
 export const getBloodlineRanking = async ({
   limit = 20,
-  period = "weekly",
+  baseDate: _baseDate,
   speciesType,
-  baseDate,
 }: {
   limit?: number;
   period?: RankingPeriod;
   speciesType?: string;
   baseDate?: Date;
 } = {}): Promise<BloodlineRankingItem[]> => {
-  // 혈통 랭킹은 파생 카드가 아니라 root 카드 기준으로 묶어 follow/거래/평균가를 합산한다.
-  const current = getKstWeekWindow(baseDate);
-  const previous = getPreviousKstWeekWindow(baseDate);
+  // 혈통 랭킹은 실사용 데이터를 우선해 root별 "실제 보유자 수" 중심으로 단순 집계한다.
   const rootWhere: Record<string, unknown> = {
     cardType: "BLOODLINE",
     status: "ACTIVE",
@@ -475,154 +472,86 @@ export const getBloodlineRanking = async ({
     rootWhere.speciesType = speciesType;
   }
 
-  const [roots, followRows, currentAuctionStats, previousAuctionStats] = await Promise.all([
-    client.bloodlineCard.findMany({
-      where: rootWhere,
-      select: {
-        id: true,
-        name: true,
-        speciesType: true,
-        image: true,
-        creator: {
-          select: {
-            id: true,
-            name: true,
-          },
+  const roots = await client.bloodlineCard.findMany({
+    where: rootWhere,
+    select: {
+      id: true,
+      name: true,
+      speciesType: true,
+      image: true,
+      createdAt: true,
+      creator: {
+        select: {
+          id: true,
+          name: true,
         },
       },
-    }),
-    countByGroup("bloodlineFollow", {}),
-    client.auction.groupBy({
-      by: ["bloodlineRootId"],
-      where: {
-        bloodlineRootId: { not: null },
-        status: "종료",
-        winnerId: { not: null },
-        ...(period === "weekly" ? { endAt: { gte: current.startAt, lte: current.endAt } } : {}),
-      },
-      _count: { _all: true },
-      _avg: { currentPrice: true },
-    }),
-    period === "weekly"
-      ? client.auction.groupBy({
-          by: ["bloodlineRootId"],
-          where: {
-            bloodlineRootId: { not: null },
-            status: "종료",
-            winnerId: { not: null },
-            endAt: { gte: previous.startAt, lte: previous.endAt },
-          },
-          _count: { _all: true },
-          _avg: { currentPrice: true },
-        })
-      : Promise.resolve([]),
-  ]);
+    },
+    orderBy: { createdAt: "desc" },
+  });
 
-  const followMap = toCountMap(followRows);
-  const currentTradeMap = new Map(
-    currentAuctionStats
-      .filter((row) => row.bloodlineRootId !== null)
-      .map((row) => [
-        row.bloodlineRootId as number,
-        {
-          tradeCount: row._count._all,
-          avgClosingPrice: Math.round(row._avg.currentPrice ?? 0),
-        },
-      ])
-  );
-  const previousTradeMap = new Map(
-    previousAuctionStats
-      .filter((row) => row.bloodlineRootId !== null)
-      .map((row) => [
-        row.bloodlineRootId as number,
-        {
-          tradeCount: row._count._all,
-          avgClosingPrice: Math.round(row._avg.currentPrice ?? 0),
-        },
-      ])
-  );
+  if (roots.length === 0) return [];
+  const rootIds = roots.map((root) => root.id);
+
+  const lineageCards = await client.bloodlineCard.findMany({
+    where: {
+      status: "ACTIVE",
+      OR: [
+        { id: { in: rootIds } },
+        { bloodlineReferenceId: { in: rootIds } },
+      ],
+      currentOwner: { status: "ACTIVE" },
+    },
+    select: {
+      id: true,
+      bloodlineReferenceId: true,
+      currentOwnerId: true,
+    },
+  });
+
+  const ownerMap = new Map<number, Set<number>>();
+  const issuedCountMap = new Map<number, number>();
+
+  lineageCards.forEach((card) => {
+    const rootId = card.bloodlineReferenceId ?? card.id;
+    const ownerSet = ownerMap.get(rootId) ?? new Set<number>();
+    ownerSet.add(card.currentOwnerId);
+    ownerMap.set(rootId, ownerSet);
+    issuedCountMap.set(rootId, (issuedCountMap.get(rootId) ?? 0) + 1);
+  });
 
   const scored = roots
     .map((root) => {
-      const currentTrade = currentTradeMap.get(root.id) ?? { tradeCount: 0, avgClosingPrice: 0 };
-      const previousTrade = previousTradeMap.get(root.id) ?? { tradeCount: 0, avgClosingPrice: 0 };
-      const followCount = followMap.get(root.id) ?? 0;
-      const growthRate7d =
-        period !== "weekly"
-          ? 0
-          : previousTrade.avgClosingPrice > 0
-          ? (currentTrade.avgClosingPrice - previousTrade.avgClosingPrice) /
-            previousTrade.avgClosingPrice
-          : currentTrade.avgClosingPrice > 0
-            ? 1
-            : 0;
-
+      const ownerCount = ownerMap.get(root.id)?.size ?? 1;
+      const issuedCount = issuedCountMap.get(root.id) ?? 1;
       return {
         root,
-        followCount,
-        tradeCount: currentTrade.tradeCount,
-        avgClosingPrice: currentTrade.avgClosingPrice,
-        growthRate7d,
-        previousScore:
-          period === "weekly"
-            ? scoreBloodline({
-                followCount,
-                tradeCount: previousTrade.tradeCount,
-                avgClosingPrice: previousTrade.avgClosingPrice,
-                growthRate7d: 0,
-              })
-            : 0,
-        score: scoreBloodline({
-          followCount,
-          tradeCount: currentTrade.tradeCount,
-          avgClosingPrice: currentTrade.avgClosingPrice,
-          growthRate7d,
-        }),
+        ownerCount,
+        issuedCount,
+        score: ownerCount * 1000 + issuedCount,
       };
     })
-    .filter((item) => item.score > 0)
-    .sort((a, b) => b.score - a.score || a.root.name.localeCompare(b.root.name, "ko"));
+    .sort(
+      (a, b) =>
+        b.ownerCount - a.ownerCount ||
+        b.issuedCount - a.issuedCount ||
+        b.root.createdAt.getTime() - a.root.createdAt.getTime()
+    );
 
-  const previousScored =
-    period === "weekly"
-      ? roots
-          .map((root) => {
-            const prev = previousTradeMap.get(root.id) ?? { tradeCount: 0, avgClosingPrice: 0 };
-            const followCount = followMap.get(root.id) ?? 0;
-            return {
-              key: root.id,
-              score: scoreBloodline({
-                followCount,
-                tradeCount: prev.tradeCount,
-                avgClosingPrice: prev.avgClosingPrice,
-                growthRate7d: 0,
-              }),
-            };
-          })
-          .filter((item) => item.score > 0)
-          .sort((a, b) => b.score - a.score || a.key - b.key)
-      : [];
-  const previousRankMap = getRankMap(previousScored);
-
-  return scored.slice(0, limit).map((item, index) => {
-    const previousMeta = previousRankMap.get(item.root.id);
-    return {
-      rank: index + 1,
-      previousRank: previousMeta?.rank ?? null,
-      rankDelta: previousMeta ? previousMeta.rank - (index + 1) : 0,
-      score: item.score,
-      scoreDelta: item.score - (previousMeta?.score ?? 0),
-      bloodlineRootId: item.root.id,
-      name: item.root.name,
-      speciesType: item.root.speciesType,
-      image: item.root.image,
-      creator: item.root.creator,
-      followCount: item.followCount,
-      tradeCount: item.tradeCount,
-      avgClosingPrice: item.avgClosingPrice,
-      growthRate7d: Number(item.growthRate7d.toFixed(4)),
-    };
-  });
+  return scored.slice(0, limit).map((item, index) => ({
+    rank: index + 1,
+    previousRank: null,
+    rankDelta: 0,
+    score: item.score,
+    scoreDelta: 0,
+    bloodlineRootId: item.root.id,
+    name: item.root.name,
+    speciesType: item.root.speciesType,
+    image: item.root.image,
+    creator: item.root.creator,
+    ownerCount: item.ownerCount,
+    issuedCount: item.issuedCount,
+  }));
 };
 
 export const getMyRankingSummary = async (userId: number): Promise<RankingMeSummary | null> => {

--- a/libs/shared/ranking.ts
+++ b/libs/shared/ranking.ts
@@ -44,10 +44,8 @@ export interface BloodlineRankingItem {
     id: number;
     name: string;
   };
-  followCount: number;
-  tradeCount: number;
-  avgClosingPrice: number;
-  growthRate7d: number;
+  ownerCount: number;
+  issuedCount: number;
 }
 
 export interface AuctionRankingItem {


### PR DESCRIPTION
## 변경 내용
- 혈통 랭킹 기준을 실제 보유자 수 중심으로 단순화
- 동률 시 총 발급 수, 생성일 순으로 정렬
- 홈 TOP 브리더 카드 밀도 조정 및 프로필 이미지 추가
- 홈 최고가 경매 카드에 경매 사진/판매자 프로필 추가
- 랭킹 상세 경매 카드 border 렌더 문제 수정

## 검증
- npm run verify:ci

## 비고
- 개발자/TODOLIST.md 수정은 포함하지 않았습니다.