### PR TITLE
[#108] 홈 화면에 재밌는 요소 추가

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,12 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "Next.js Dev Server",
+      "runtimeExecutable": "/Users/yoonseongjun/.nvm/versions/node/v20.19.3/bin/node",
+      "runtimeArgs": ["/Users/yoonseongjun/Desktop/pro/breeder_web/node_modules/.bin/next", "dev", "--webpack"],
+      "port": 3000,
+      "autoPort": false
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -155,11 +155,11 @@ docs/               Internal project docs
 ```
 
 ## API Docs
-- 상품 API 문서: [pages/api/products.md](/Users/yoonseongjun/Desktop/pro/breeder_web/pages/api/products.md)
-- 유저 API 문서: [pages/api/users.md](/Users/yoonseongjun/Desktop/pro/breeder_web/pages/api/users.md)
+- 상품 API 문서: [pages/api/products.md](./pages/api/products.md)
+- 유저 API 문서: [pages/api/users.md](./pages/api/users.md)
 
 ## Development Rules
-- 프로젝트 룰: [AGENTS.md](/Users/yoonseongjun/Desktop/pro/breeder_web/AGENTS.md), `.cursor/rules/`
+- 프로젝트 룰: [AGENTS.md](./AGENTS.md), `.cursor/rules/`
 - API 룰: `.cursor/rules/api-rule.mdc`
 - 페이지 룰: `.cursor/rules/page-rule.mdc`
 - DB 접근은 `libs/server/client.ts`를 통해 수행

--- a/app/(web)/(main)/MainClient.tsx
+++ b/app/(web)/(main)/MainClient.tsx
@@ -315,7 +315,47 @@ const MainClient = ({
         </div>
       </section>
 
-      {/* Section 2: TOP 브리더 hero card */}
+      {/* Section 2: 혈통카드 공유 챌린지 (compact) */}
+      <section className="app-section app-reveal app-reveal-1 py-2">
+        <div className="relative mx-5 overflow-hidden rounded-2xl bg-gradient-to-br from-amber-400 via-orange-400 to-rose-500 p-3 text-white shadow-lg">
+          <div className="pointer-events-none absolute -right-4 -top-4 h-16 w-16 rounded-full bg-white/15 blur-xl" />
+          <div className="flex items-center justify-between gap-3">
+            <div className="min-w-0 flex-1">
+              <div className="flex items-center gap-2">
+                <span className="inline-flex items-center rounded-full bg-white/25 px-2 py-0.5 text-[9px] font-bold uppercase tracking-widest">
+                  이벤트
+                </span>
+                <h3 className="text-sm font-black leading-tight">혈통카드 공유 챌린지</h3>
+              </div>
+              <p className="mt-1 text-[11px] leading-snug text-white/90">
+                내 혈통카드를 공유하고 특별 배지를 받으세요!
+              </p>
+            </div>
+            <div className="flex shrink-0 gap-1.5">
+              <Link
+                href="/bloodline-management"
+                onClick={() =>
+                  trackEvent(ANALYTICS_EVENTS.challengeJoin, {
+                    challenge_id: "bloodline_card_share",
+                    entry_type: user ? "member" : "guest",
+                  })
+                }
+                className="inline-flex h-7 items-center rounded-full bg-white px-3 text-[11px] font-bold text-orange-600"
+              >
+                보기
+              </Link>
+              <Link
+                href="/bloodline-cards/create"
+                className="inline-flex h-7 items-center rounded-full border border-white/40 bg-white/20 px-3 text-[11px] font-semibold text-white backdrop-blur-sm"
+              >
+                만들기
+              </Link>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Section 3: TOP 브리더 hero card */}
       <section className="app-section app-reveal app-reveal-1 py-2">
         <SectionHeader
           title="이번 주 TOP 브리더"
@@ -414,7 +454,7 @@ const MainClient = ({
                 section_id: "auction_ranking",
               })
             }
-            className="app-card app-card-interactive flex flex-col justify-between p-3 min-h-[160px]"
+            className="app-card app-card-interactive flex flex-col gap-2 p-3"
           >
             <div>
               <div className="flex items-center justify-between">
@@ -425,7 +465,7 @@ const MainClient = ({
             </div>
             <div className="mt-2 space-y-1.5">
               {homeFeedData?.topAuctionsByCategory?.length ? (
-                homeFeedData.topAuctionsByCategory.slice(0, 1).map((auction) => (
+                homeFeedData.topAuctionsByCategory.slice(0, 2).map((auction) => (
                   <div key={auction.auctionId} className="flex items-center gap-2">
                     <div className="h-8 w-8 shrink-0 overflow-hidden rounded-lg bg-slate-100">
                       {auction.photo ? (
@@ -463,7 +503,7 @@ const MainClient = ({
                 section_id: "bloodline_ranking",
               })
             }
-            className="app-card app-card-interactive flex flex-col justify-between p-3 min-h-[160px]"
+            className="app-card app-card-interactive flex flex-col gap-2 p-3"
           >
             <div>
               <div className="flex items-center justify-between">
@@ -474,7 +514,7 @@ const MainClient = ({
             </div>
             <div className="mt-2 space-y-1.5">
               {homeFeedData?.topBloodlines?.length ? (
-                homeFeedData.topBloodlines.slice(0, 1).map((bloodline) => (
+                homeFeedData.topBloodlines.slice(0, 2).map((bloodline) => (
                   <div key={bloodline.bloodlineRootId} className="flex items-center gap-2">
                     <div className="h-8 w-8 shrink-0 overflow-hidden rounded-lg bg-slate-100">
                       {bloodline.image ? (
@@ -514,7 +554,7 @@ const MainClient = ({
                 section_id: "trending_community",
               })
             }
-            className="app-card app-card-interactive flex flex-col justify-between p-3 min-h-[160px]"
+            className="app-card app-card-interactive flex flex-col gap-2 p-3"
           >
             <div>
               <div className="flex items-center justify-between">
@@ -551,7 +591,7 @@ const MainClient = ({
                   section_id: "free_giveaway",
                 })
               }
-              className="app-card app-card-interactive flex flex-col justify-between p-3 min-h-[160px]"
+              className="app-card app-card-interactive flex flex-col gap-2 p-3"
             >
               <div>
                 <div className="flex items-center justify-between">
@@ -585,53 +625,13 @@ const MainClient = ({
           ) : (
             <Link
               href="/products/upload"
-              className="app-card app-card-interactive flex flex-col items-center justify-center p-3 min-h-[160px] text-center"
+              className="app-card app-card-interactive flex flex-col items-center justify-center p-3 text-center"
             >
               <h3 className="text-sm font-bold text-slate-900">무료나눔</h3>
               <p className="mt-2 text-xs text-slate-500">아직 무료나눔이 없어요</p>
               <p className="mt-1 text-[10px] font-semibold text-primary">첫 번째로 등록해보세요 ›</p>
             </Link>
           )}
-        </div>
-      </section>
-
-      {/* Section 4: 혈통카드 공유 챌린지 (compact) */}
-      <section className="app-section app-reveal app-reveal-2 py-2">
-        <div className="relative mx-5 overflow-hidden rounded-2xl bg-gradient-to-br from-amber-400 via-orange-400 to-rose-500 p-3 text-white shadow-lg">
-          <div className="pointer-events-none absolute -right-4 -top-4 h-16 w-16 rounded-full bg-white/15 blur-xl" />
-          <div className="flex items-center justify-between gap-3">
-            <div className="min-w-0 flex-1">
-              <div className="flex items-center gap-2">
-                <span className="inline-flex items-center rounded-full bg-white/25 px-2 py-0.5 text-[9px] font-bold uppercase tracking-widest">
-                  이벤트
-                </span>
-                <h3 className="text-sm font-black leading-tight">혈통카드 공유 챌린지</h3>
-              </div>
-              <p className="mt-1 text-[11px] leading-snug text-white/90">
-                내 혈통카드를 공유하고 특별 배지를 받으세요!
-              </p>
-            </div>
-            <div className="flex shrink-0 gap-1.5">
-              <Link
-                href="/bloodline-management"
-                onClick={() =>
-                  trackEvent(ANALYTICS_EVENTS.challengeJoin, {
-                    challenge_id: "bloodline_card_share",
-                    entry_type: user ? "member" : "guest",
-                  })
-                }
-                className="inline-flex h-7 items-center rounded-full bg-white px-3 text-[11px] font-bold text-orange-600"
-              >
-                보기
-              </Link>
-              <Link
-                href="/bloodline-cards/create"
-                className="inline-flex h-7 items-center rounded-full border border-white/40 bg-white/20 px-3 text-[11px] font-semibold text-white backdrop-blur-sm"
-              >
-                만들기
-              </Link>
-            </div>
-          </div>
         </div>
       </section>
 

--- a/app/(web)/(main)/MainClient.tsx
+++ b/app/(web)/(main)/MainClient.tsx
@@ -355,7 +355,7 @@ const MainClient = ({
         </div>
       </section>
 
-      {/* Section 3: TOP 브리더 hero card */}
+      {/* Section 3: TOP 브리더 */}
       <section className="app-section app-reveal app-reveal-1 py-2">
         <SectionHeader
           title="이번 주 TOP 브리더"
@@ -364,56 +364,43 @@ const MainClient = ({
         />
         <div className="mt-1 px-5">
           {homeFeedData?.heroBreeder ? (
-            // 첫 스크린은 주간 1위 브리더와 즉시 행동 CTA에 집중해 홈 방향성을 명확히 준다.
-            <div className="relative overflow-hidden rounded-3xl bg-[radial-gradient(circle_at_top_left,_rgba(29,78,216,0.22),_transparent_38%),linear-gradient(135deg,#0f172a,#111827_55%,#1d4ed8)] p-4 text-white shadow-xl">
-              <p className="app-kicker text-white/70 text-[10px]">
-                {heroBreederPeriod === "weekly" ? "Weekly Hero" : "All-time Leader"}
-              </p>
-              <div className="mt-3 flex items-start justify-between gap-3">
+            <div className="app-card overflow-hidden border border-slate-200/80 p-0">
+              {/* 상단: 프로필 + 순위 */}
+              <div className="flex items-center gap-3 px-4 pt-3.5 pb-3">
+                <div className="relative">
+                  <div className="h-11 w-11 overflow-hidden rounded-full bg-slate-100 ring-2 ring-amber-400/60">
+                    {homeFeedData.heroBreeder.user.avatar ? (
+                      <Image
+                        src={makeImageUrl(homeFeedData.heroBreeder.user.avatar, "avatar")}
+                        alt={homeFeedData.heroBreeder.user.name}
+                        width={44}
+                        height={44}
+                        className="h-full w-full object-cover"
+                      />
+                    ) : (
+                      <div className="flex h-full w-full items-center justify-center bg-slate-200 text-sm font-bold text-slate-500">
+                        {homeFeedData.heroBreeder.user.name.charAt(0)}
+                      </div>
+                    )}
+                  </div>
+                  <span className="absolute -bottom-0.5 -right-0.5 flex h-5 w-5 items-center justify-center rounded-full bg-amber-400 text-[9px] font-black text-white shadow-sm">
+                    {homeFeedData.heroBreeder.rank}
+                  </span>
+                </div>
                 <div className="min-w-0 flex-1">
-                  <div className="flex items-center gap-2.5">
-                    <div className="h-10 w-10 overflow-hidden rounded-2xl bg-white/10 ring-1 ring-white/15">
-                      {homeFeedData.heroBreeder.user.avatar ? (
-                        <Image
-                          src={makeImageUrl(homeFeedData.heroBreeder.user.avatar, "avatar")}
-                          alt={homeFeedData.heroBreeder.user.name}
-                          width={40}
-                          height={40}
-                          className="h-full w-full object-cover"
-                        />
-                      ) : null}
-                    </div>
-                    <div className="min-w-0">
-                      <h3 className="truncate text-xl font-black tracking-tight">
-                        {homeFeedData.heroBreeder.user.name}
-                      </h3>
-                      <p className="mt-0.5 text-xs text-white/75">
-                        브리더 랭킹 {homeFeedData.heroBreeder.rank}위
-                      </p>
-                    </div>
+                  <div className="flex items-center gap-1.5">
+                    <h3 className="truncate text-sm font-bold text-slate-900">
+                      {homeFeedData.heroBreeder.user.name}
+                    </h3>
+                    {(homeFeedData.heroBreeder.badges || []).slice(0, 1).map((badge) => (
+                      <span key={badge.id} className="shrink-0 rounded bg-amber-50 px-1.5 py-0.5 text-[9px] font-semibold text-amber-600">
+                        {badge.label}
+                      </span>
+                    ))}
                   </div>
-                  <p className="mt-2 text-sm text-white/75">
-                    점수 {homeFeedData.heroBreeder.score.toLocaleString()} · {formatRankDelta(homeFeedData.heroBreeder.rankDelta)}
+                  <p className="mt-0.5 text-xs text-slate-500">
+                    {homeFeedData.heroBreeder.score.toLocaleString()}점 · {formatRankDelta(homeFeedData.heroBreeder.rankDelta)}
                   </p>
-                  <div className="mt-3 flex flex-wrap gap-1.5 text-[10px]">
-                    <span className="rounded-full bg-white/10 px-2 py-1">게시 {homeFeedData.heroBreeder.postsCount}</span>
-                    <span className="rounded-full bg-white/10 px-2 py-1">댓글 {homeFeedData.heroBreeder.commentsCount}</span>
-                    <span className="rounded-full bg-white/10 px-2 py-1">입찰 {homeFeedData.heroBreeder.bidsCount}</span>
-                    <span className="rounded-full bg-white/10 px-2 py-1">낙찰 {homeFeedData.heroBreeder.auctionWinsCount}</span>
-                  </div>
-                </div>
-                <div className="rounded-2xl bg-white/10 px-3 py-2 text-right backdrop-blur-sm">
-                  <p className="text-[10px] text-white/70">현재 순위</p>
-                  <p className="text-2xl font-black">#{homeFeedData.heroBreeder.rank}</p>
-                </div>
-              </div>
-              <div className="mt-3 flex items-center justify-between gap-3">
-                <div className="flex flex-wrap gap-1.5">
-                  {(homeFeedData.heroBreeder.badges || []).slice(0, 2).map((badge) => (
-                    <span key={badge.id} className="rounded-full border border-white/15 bg-white/10 px-2 py-1 text-[10px] font-semibold">
-                      {badge.label}
-                    </span>
-                  ))}
                 </div>
                 <button
                   type="button"
@@ -428,10 +415,24 @@ const MainClient = ({
                         : "/auth/login?next=%2Franking%3Ftab%3Dbreeders%26period%3Dweekly"
                     );
                   }}
-                  className="inline-flex h-8 items-center rounded-full bg-white px-3.5 text-xs font-semibold text-slate-900"
+                  className="shrink-0 rounded-full bg-slate-900 px-3 py-1.5 text-[11px] font-semibold text-white transition-colors hover:bg-slate-800"
                 >
-                  내 순위 올리기
+                  도전하기
                 </button>
+              </div>
+              {/* 하단: 활동 스탯 바 */}
+              <div className="flex border-t border-slate-100 divide-x divide-slate-100">
+                {[
+                  { label: "게시", value: homeFeedData.heroBreeder.postsCount },
+                  { label: "댓글", value: homeFeedData.heroBreeder.commentsCount },
+                  { label: "입찰", value: homeFeedData.heroBreeder.bidsCount },
+                  { label: "낙찰", value: homeFeedData.heroBreeder.auctionWinsCount },
+                ].map((stat) => (
+                  <div key={stat.label} className="flex-1 py-2.5 text-center">
+                    <p className="text-sm font-bold text-slate-900">{stat.value}</p>
+                    <p className="text-[10px] text-slate-400">{stat.label}</p>
+                  </div>
+                ))}
               </div>
             </div>
           ) : (

--- a/app/(web)/(main)/MainClient.tsx
+++ b/app/(web)/(main)/MainClient.tsx
@@ -17,8 +17,6 @@ import { cn, makeImageUrl } from "@libs/client/utils";
 import { CATEGORIES } from "@libs/constants";
 import { ANALYTICS_EVENTS, trackEvent } from "@libs/client/analytics";
 import useUser from "hooks/useUser";
-import { toAuctionPath } from "@libs/auction-route";
-import { toPostPath } from "@libs/post-route";
 import { FreeProductItem, HomeFeedResponse } from "@libs/shared/ranking";
 import { HomeBanner, ProductsResponse } from "@libs/shared/home";
 
@@ -66,9 +64,6 @@ const formatRankDelta = (rankDelta: number) => {
   return "유지";
 };
 
-const formatGrowthRate = (growthRate: number) => {
-  return `${growthRate >= 0 ? "+" : ""}${Math.round(growthRate * 100)}%`;
-};
 
 const toRankingHref = (tab: "breeders" | "auctions" | "bloodlines" | "community", period: "weekly" | "all") =>
   `/ranking?tab=${tab}&period=${period}`;
@@ -275,7 +270,7 @@ const MainClient = ({
           onScroll={handleBannerScroll}
           className="app-rail flex gap-0"
         >
-            {banners.map((banner: any) => (
+            {banners.map((banner) => (
               <Link
                 key={banner.id}
                 href={banner.href}
@@ -306,7 +301,7 @@ const MainClient = ({
 
         </div>
         <div className="mt-3 flex items-center justify-center gap-1.5">
-          {banners.map((banner: any, index: number) => (
+          {banners.map((banner, index: number) => (
             <button
               key={banner.id}
               onClick={() => scrollToBanner(index)}

--- a/app/(web)/(main)/MainClient.tsx
+++ b/app/(web)/(main)/MainClient.tsx
@@ -19,7 +19,7 @@ import { ANALYTICS_EVENTS, trackEvent } from "@libs/client/analytics";
 import useUser from "hooks/useUser";
 import { toAuctionPath } from "@libs/auction-route";
 import { toPostPath } from "@libs/post-route";
-import { HomeFeedResponse } from "@libs/shared/ranking";
+import { FreeProductItem, HotDiscussionItem, HomeFeedResponse } from "@libs/shared/ranking";
 import { HomeBanner, ProductsResponse } from "@libs/shared/home";
 
 interface BeforeInstallPromptEvent extends Event {
@@ -623,6 +623,160 @@ const MainClient = ({
               대표 혈통을 공개하고 거래/보유 이력을 신뢰 레이어로 연결하세요.
             </p>
           </Link>
+        </div>
+      </section>
+
+      {/* 혈통카드 공유 챌린지 */}
+      <section className="app-section app-reveal app-reveal-2 py-2">
+        <div className="relative mx-5 overflow-hidden rounded-3xl bg-gradient-to-br from-amber-400 via-orange-400 to-rose-500 p-4 text-white shadow-lg">
+          <div className="pointer-events-none absolute -right-4 -top-4 h-20 w-20 rounded-full bg-white/15 blur-xl" />
+          <div className="flex items-start justify-between gap-3">
+            <div className="min-w-0 flex-1">
+              <span className="inline-flex items-center gap-1 rounded-full bg-white/25 px-2 py-0.5 text-[10px] font-bold uppercase tracking-widest">
+                🎁 이벤트
+              </span>
+              <h3 className="mt-2 text-base font-black leading-tight">혈통카드 공유 챌린지</h3>
+              <p className="mt-1 text-xs leading-snug text-white/90">
+                내 혈통카드를 지인에게 선물하거나 커뮤니티에 공유해보세요.
+                활발한 공유자에게 특별 배지가 지급됩니다!
+              </p>
+            </div>
+          </div>
+          <div className="mt-3 flex gap-2">
+            <Link
+              href="/bloodline-management"
+              onClick={() =>
+                trackEvent(ANALYTICS_EVENTS.challengeJoin, {
+                  challenge_id: "bloodline_card_share",
+                  entry_type: user ? "member" : "guest",
+                })
+              }
+              className="inline-flex h-8 items-center rounded-full bg-white px-4 text-xs font-bold text-orange-600"
+            >
+              내 혈통카드 보기
+            </Link>
+            <Link
+              href="/bloodline-cards/create"
+              className="inline-flex h-8 items-center rounded-full border border-white/40 bg-white/20 px-4 text-xs font-semibold text-white backdrop-blur-sm"
+            >
+              카드 만들기
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      {/* 오늘의 무료나눔 */}
+      <section className="app-section app-reveal app-reveal-2 py-2">
+        <SectionHeader
+          title="오늘의 무료나눔"
+          subtitle="가격 0원 · 지금 바로 연락해보세요"
+          href="/products?status=판매중&price=0"
+          actionLabel="더보기"
+        />
+        <div className="mt-1 px-5">
+          {homeFeedData?.freeGiveawayProducts?.length ? (
+            <div className="app-rail flex gap-3">
+              {homeFeedData.freeGiveawayProducts.map((item: FreeProductItem) => (
+                <Link
+                  key={item.id}
+                  href={`/products/${item.id}`}
+                  className="snap-start shrink-0 w-44 app-card app-card-interactive p-3"
+                >
+                  <div className="relative h-28 w-full overflow-hidden rounded-2xl bg-slate-100">
+                    {item.photos[0] ? (
+                      <Image
+                        src={makeImageUrl(item.photos[0], "public")}
+                        alt={item.name}
+                        width={176}
+                        height={112}
+                        className="h-full w-full object-cover"
+                      />
+                    ) : null}
+                    <span className="absolute left-2 top-2 rounded-full bg-emerald-500 px-2 py-0.5 text-[10px] font-bold text-white">
+                      무료
+                    </span>
+                  </div>
+                  <div className="mt-2">
+                    <p className="line-clamp-2 text-xs font-semibold text-slate-800">{item.name}</p>
+                    <p className="mt-1 text-[11px] text-slate-500">{item.user.name}</p>
+                    <div className="mt-1 flex items-center gap-1 text-[11px] text-slate-400">
+                      <span>❤️ {item._count.favs}</span>
+                    </div>
+                  </div>
+                </Link>
+              ))}
+            </div>
+          ) : (
+            <div className="app-card p-4 text-sm text-slate-400">
+              현재 무료나눔 상품이 없습니다. 나중에 다시 확인해보세요!
+            </div>
+          )}
+        </div>
+      </section>
+
+      {/* 실시간 HOT 토론 */}
+      <section className="app-section app-reveal app-reveal-2 py-2">
+        <SectionHeader
+          title="실시간 HOT 토론"
+          subtitle="지금 가장 뜨거운 대화 · 48시간 기준"
+          href="/posts"
+          actionLabel="더보기"
+        />
+        <div className="mt-1 px-5 flex flex-col gap-2.5">
+          {homeFeedData?.hotDiscussions?.length ? (
+            homeFeedData.hotDiscussions.map((item: HotDiscussionItem, index: number) => (
+              <Link
+                key={item.id}
+                href={toPostPath(item.id, item.title)}
+                onClick={() =>
+                  trackEvent(ANALYTICS_EVENTS.rankingCardClick, {
+                    ranking_type: "community",
+                    rank: index + 1,
+                    entity_id: item.id,
+                    section_id: "hot_discussion",
+                  })
+                }
+                className="app-card app-card-interactive flex items-start gap-3 p-3.5"
+              >
+                <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-xl bg-rose-50 text-sm font-black text-rose-500">
+                  {index + 1}
+                </div>
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-1.5">
+                    {item.category ? (
+                      <span className="rounded-full bg-slate-100 px-1.5 py-0.5 text-[10px] font-medium text-slate-500">
+                        {item.category}
+                      </span>
+                    ) : null}
+                    <span className="inline-flex items-center gap-0.5 rounded-full bg-rose-100 px-1.5 py-0.5 text-[10px] font-bold text-rose-600">
+                      🔥 HOT
+                    </span>
+                  </div>
+                  <h3 className="mt-1 line-clamp-2 text-sm font-semibold text-slate-900">{item.title}</h3>
+                  <div className="mt-1.5 flex items-center gap-3 text-[11px] text-slate-500">
+                    <span>{item.user.name}</span>
+                    <span>💬 댓글 {item.commentsCount}</span>
+                    <span>👍 {item.wonderCount}</span>
+                  </div>
+                </div>
+                {item.image ? (
+                  <div className="h-14 w-14 shrink-0 overflow-hidden rounded-xl bg-slate-100">
+                    <Image
+                      src={makeImageUrl(item.image, "public")}
+                      alt={item.title}
+                      width={56}
+                      height={56}
+                      className="h-full w-full object-cover"
+                    />
+                  </div>
+                ) : null}
+              </Link>
+            ))
+          ) : (
+            <div className="app-card p-4 text-sm text-slate-400">
+              뜨거운 토론이 시작되면 여기에 표시됩니다. 먼저 글을 올려보세요!
+            </div>
+          )}
         </div>
       </section>
 

--- a/app/(web)/(main)/MainClient.tsx
+++ b/app/(web)/(main)/MainClient.tsx
@@ -181,6 +181,9 @@ const MainClient = ({
       "auction_ranking",
       "bloodline_ranking",
       "trending_community",
+      "bloodline_card_share",
+      "free_giveaway",
+      "hot_discussion",
       "personalized_home",
     ];
     sectionIds.forEach((sectionId, index) => {
@@ -676,10 +679,18 @@ const MainClient = ({
         <div className="mt-1 px-5">
           {homeFeedData?.freeGiveawayProducts?.length ? (
             <div className="app-rail flex gap-3">
-              {homeFeedData.freeGiveawayProducts.map((item: FreeProductItem) => (
+              {homeFeedData.freeGiveawayProducts.map((item: FreeProductItem, index: number) => (
                 <Link
                   key={item.id}
                   href={`/products/${item.id}`}
+                  onClick={() =>
+                    trackEvent(ANALYTICS_EVENTS.rankingCardClick, {
+                      ranking_type: "free_giveaway",
+                      rank: index + 1,
+                      entity_id: item.id,
+                      section_id: "free_giveaway",
+                    })
+                  }
                   className="snap-start shrink-0 w-44 app-card app-card-interactive p-3"
                 >
                   <div className="relative h-28 w-full overflow-hidden rounded-2xl bg-slate-100">

--- a/app/(web)/(main)/MainClient.tsx
+++ b/app/(web)/(main)/MainClient.tsx
@@ -268,7 +268,7 @@ const MainClient = ({
 
   return (
     <div className="app-page flex flex-col h-full">
-      {/* 상단 배너/히어로 */}
+      {/* Section 1: 상단 배너/히어로 */}
       <section className="app-reveal">
         <div
           ref={bannerRef}
@@ -303,7 +303,7 @@ const MainClient = ({
                 <div className="pointer-events-none absolute -right-8 -top-10 h-28 w-28 rounded-full bg-white/12" />
               </Link>
             ))}
-          
+
         </div>
         <div className="mt-3 flex items-center justify-center gap-1.5">
           {banners.map((banner: any, index: number) => (
@@ -320,6 +320,7 @@ const MainClient = ({
         </div>
       </section>
 
+      {/* Section 2: TOP 브리더 hero card */}
       <section className="app-section app-reveal app-reveal-1 py-2">
         <SectionHeader
           title="이번 주 TOP 브리더"
@@ -404,242 +405,218 @@ const MainClient = ({
         </div>
       </section>
 
+      {/* Section 3: 2x2 Grid — 경매 / 혈통 / 커뮤니티 / 무료나눔 */}
       <section className="app-section app-reveal app-reveal-1 py-2">
-        <SectionHeader
-          title="카테고리별 최고가 경매"
-          href={toRankingHref("auctions", auctionPeriod)}
-        />
-        <div className="mt-1 px-5">
-          <div className="app-rail flex gap-3">
-            {homeFeedData?.topAuctionsByCategory?.length ? (
-              homeFeedData.topAuctionsByCategory.map((auction, index) => (
-                <Link
-                  key={auction.auctionId}
-                  href={toAuctionPath(auction.auctionId, auction.title)}
-                  onClick={() => {
-                    trackEvent(ANALYTICS_EVENTS.rankingCardClick, {
-                      ranking_type: "auction",
-                      rank: auction.rank,
-                      entity_id: auction.auctionId,
-                      section_id: "auction_ranking",
-                    });
-                    trackEvent(ANALYTICS_EVENTS.homeOngoingAuctionClicked, {
-                      auction_id: auction.auctionId,
-                      auction_title: auction.title,
-                      rank_index: index,
-                      current_price: auction.currentPrice,
-                      user_id: user?.id || null,
-                    });
-                  }}
-                  className="snap-start shrink-0 w-64 app-card app-card-interactive p-3.5"
-                >
-                  <div className="flex gap-3">
-                    <div className="h-16 w-16 shrink-0 overflow-hidden rounded-2xl bg-slate-100">
+        <div className="grid grid-cols-2 gap-3 px-5">
+          {/* 최고가 경매 */}
+          <Link
+            href={toRankingHref("auctions", auctionPeriod)}
+            onClick={() =>
+              trackEvent(ANALYTICS_EVENTS.rankingCardClick, {
+                ranking_type: "auction",
+                rank: 1,
+                entity_id: homeFeedData?.topAuctionsByCategory?.[0]?.auctionId ?? "",
+                section_id: "auction_ranking",
+              })
+            }
+            className="app-card app-card-interactive flex flex-col justify-between p-3 min-h-[160px]"
+          >
+            <div>
+              <div className="flex items-center justify-between">
+                <h3 className="text-sm font-bold text-slate-900">최고가 경매</h3>
+                <span className="text-[10px] text-slate-400">더보기 ›</span>
+              </div>
+              <p className="mt-0.5 text-[10px] text-slate-400">카테고리별 최고 낙찰가</p>
+            </div>
+            <div className="mt-2 space-y-1.5">
+              {homeFeedData?.topAuctionsByCategory?.length ? (
+                homeFeedData.topAuctionsByCategory.slice(0, 1).map((auction) => (
+                  <div key={auction.auctionId} className="flex items-center gap-2">
+                    <div className="h-8 w-8 shrink-0 overflow-hidden rounded-lg bg-slate-100">
                       {auction.photo ? (
                         <Image
                           src={makeImageUrl(auction.photo, "public")}
                           alt={auction.title}
-                          width={64}
-                          height={64}
-                          className="h-full w-full object-cover"
-                        />
-                      ) : null}
-                    </div>
-                    <div className="min-w-0 flex-1">
-                      <p className="app-kicker">{auction.topLevelCategory}</p>
-                      <h3 className="mt-1.5 line-clamp-2 text-sm font-semibold text-slate-900">{auction.title}</h3>
-                      <p className="mt-2 text-lg font-black tracking-tight text-primary">
-                        {auction.currentPrice.toLocaleString()}원
-                      </p>
-                    </div>
-                  </div>
-                  <div className="mt-3 flex items-center gap-2.5">
-                    <div className="h-8 w-8 overflow-hidden rounded-full bg-slate-100">
-                      {auction.seller.avatar ? (
-                        <Image
-                          src={makeImageUrl(auction.seller.avatar, "avatar")}
-                          alt={auction.seller.name}
                           width={32}
                           height={32}
                           className="h-full w-full object-cover"
                         />
                       ) : null}
                     </div>
-                    <div className="min-w-0">
-                      <p className="truncate text-xs font-medium text-slate-700">{auction.seller.name}</p>
-                      <p className="text-[11px] text-slate-500">
-                        {new Date(auction.endAt).toLocaleDateString("ko-KR")}
+                    <div className="min-w-0 flex-1">
+                      <p className="truncate text-xs font-medium text-slate-700">{auction.title}</p>
+                      <p className="text-[10px] text-primary font-semibold">
+                        {auction.currentPrice.toLocaleString()}원
                       </p>
                     </div>
                   </div>
-                </Link>
-              ))
-            ) : (
-              <div className="app-card p-4 text-sm text-slate-400">집계 가능한 낙찰 데이터가 없습니다.</div>
-            )}
-          </div>
-        </div>
-      </section>
+                ))
+              ) : (
+                <p className="text-[10px] text-slate-400">집계 준비 중</p>
+              )}
+            </div>
+          </Link>
 
-      <section className="app-section app-reveal app-reveal-1 py-2">
-        <SectionHeader
-          title="인기 혈통 TOP"
-          subtitle={bloodlineSubtitle}
-          href={toRankingHref("bloodlines", bloodlinePeriod)}
-          actionLabel="랭킹 보기"
-        />
-        <div className="mt-1 px-5">
-          <div className="app-rail flex gap-3">
-            {homeFeedData?.topBloodlines?.length ? (
-              homeFeedData.topBloodlines.map((bloodline) => (
-                <Link
-                  key={bloodline.bloodlineRootId}
-                  href={`/bloodline-management/card/${bloodline.bloodlineRootId}`}
-                  onClick={() =>
-                    trackEvent(ANALYTICS_EVENTS.rankingCardClick, {
-                      ranking_type: "bloodline",
-                      rank: bloodline.rank,
-                      entity_id: bloodline.bloodlineRootId,
-                      section_id: "bloodline_ranking",
-                    })
-                  }
-                  className="snap-start shrink-0 w-64 rounded-3xl border border-slate-200 bg-white p-4 shadow-sm"
-                >
-                  <div className="flex items-center gap-3">
-                    <div className="h-14 w-14 overflow-hidden rounded-2xl bg-slate-100">
+          {/* 인기 혈통 TOP */}
+          <Link
+            href={toRankingHref("bloodlines", bloodlinePeriod)}
+            onClick={() =>
+              trackEvent(ANALYTICS_EVENTS.rankingCardClick, {
+                ranking_type: "bloodline",
+                rank: 1,
+                entity_id: homeFeedData?.topBloodlines?.[0]?.bloodlineRootId ?? "",
+                section_id: "bloodline_ranking",
+              })
+            }
+            className="app-card app-card-interactive flex flex-col justify-between p-3 min-h-[160px]"
+          >
+            <div>
+              <div className="flex items-center justify-between">
+                <h3 className="text-sm font-bold text-slate-900">인기 혈통 TOP</h3>
+                <span className="text-[10px] text-slate-400">더보기 ›</span>
+              </div>
+              <p className="mt-0.5 text-[10px] text-slate-400">보유자 수 기준 랭킹</p>
+            </div>
+            <div className="mt-2 space-y-1.5">
+              {homeFeedData?.topBloodlines?.length ? (
+                homeFeedData.topBloodlines.slice(0, 1).map((bloodline) => (
+                  <div key={bloodline.bloodlineRootId} className="flex items-center gap-2">
+                    <div className="h-8 w-8 shrink-0 overflow-hidden rounded-lg bg-slate-100">
                       {bloodline.image ? (
                         <Image
                           src={makeImageUrl(bloodline.image, "public")}
                           alt={bloodline.name}
-                          width={56}
-                          height={56}
+                          width={32}
+                          height={32}
                           className="h-full w-full object-cover"
                         />
                       ) : (
-                        <div className="flex h-full w-full items-end bg-[radial-gradient(circle_at_top_left,rgba(255,255,255,0.85),transparent_35%),linear-gradient(145deg,#111827,#1f2937_58%,#f59e0b)] p-2">
-                          <span className="text-[9px] font-semibold tracking-[0.2em] text-white/80">
-                            BLOODLINE
-                          </span>
+                        <div className="flex h-full w-full items-end bg-[linear-gradient(145deg,#111827,#1f2937_58%,#f59e0b)] p-1">
+                          <span className="text-[6px] font-semibold tracking-wider text-white/80">BL</span>
                         </div>
                       )}
                     </div>
                     <div className="min-w-0 flex-1">
-                      <p className="text-xs font-bold text-amber-500">#{bloodline.rank}</p>
-                      <h3 className="truncate text-sm font-semibold text-slate-900">{bloodline.name}</h3>
-                      <p className="text-xs text-slate-500">
-                        {bloodline.speciesType || "종 미지정"} · {bloodline.creator.name}
-                      </p>
+                      <p className="truncate text-xs font-medium text-slate-700">{bloodline.name}</p>
+                      <p className="text-[10px] text-slate-400">보유자 {bloodline.ownerCount}명</p>
                     </div>
                   </div>
-                  <div className="mt-3 grid grid-cols-2 gap-2 text-[11px] text-slate-600">
-                    <div className="rounded-2xl bg-slate-50 px-3 py-2">보유자 {bloodline.ownerCount}</div>
-                    <div className="rounded-2xl bg-slate-50 px-3 py-2">발급 수 {bloodline.issuedCount}</div>
-                  </div>
-                </Link>
-              ))
-            ) : (
-              <div className="app-card p-4 text-sm text-slate-400">집계 가능한 혈통 활동이 아직 부족합니다.</div>
-            )}
-          </div>
-        </div>
-      </section>
-
-      <section className="app-section app-reveal app-reveal-1 py-2">
-        <SectionHeader
-          title="급상승 커뮤니티"
-          subtitle={communitySubtitle}
-          href={toRankingHref("community", communityPeriod)}
-        />
-        <div className="mt-1 px-5">
-          <div className="app-rail flex gap-3">
-            {homeFeedData?.trendingPosts?.length ? (
-              homeFeedData.trendingPosts.map((item) => (
-                <Link
-                  key={item.post.id}
-                  href={toPostPath(item.post.id, item.post.title)}
-                  onClick={() =>
-                    trackEvent(ANALYTICS_EVENTS.rankingCardClick, {
-                      ranking_type: "community",
-                      rank: item.rank,
-                      entity_id: item.post.id,
-                      section_id: "trending_community",
-                    })
-                  }
-                  className="snap-start shrink-0 w-64 app-card app-card-interactive p-3"
-                >
-                  <div className="flex items-start justify-between gap-2">
-                    <div className="min-w-0 flex-1">
-                      <p className="text-xs font-bold text-rose-500">#{item.rank} 상승중</p>
-                      <h3 className="mt-1.5 line-clamp-2 text-sm font-semibold text-slate-900">
-                        {item.post.title}
-                      </h3>
-                      <p className="mt-1 line-clamp-2 text-xs leading-snug text-slate-500">
-                        {item.post.description}
-                      </p>
-                      <div className="mt-2 flex items-center gap-2 text-[11px] text-slate-500">
-                        <span>{item.post.user.name}</span>
-                        <span>좋아요 {item.likes24h}</span>
-                        <span>댓글 {item.comments24h}</span>
-                      </div>
-                    </div>
-                    {item.post.image ? (
-                      <div className="h-16 w-16 overflow-hidden rounded-xl bg-slate-100">
-                        <Image
-                          src={makeImageUrl(item.post.image, "public")}
-                          className="h-full w-full object-cover"
-                          width={64}
-                          height={64}
-                          alt={item.post.title}
-                        />
-                      </div>
-                    ) : null}
-                  </div>
-                </Link>
-              ))
-            ) : (
-              <div className="app-card p-4 text-sm text-slate-400">급상승 글이 집계되면 여기에 표시됩니다.</div>
-            )}
-          </div>
-        </div>
-      </section>
-
-      {/* 혈통카드 (CTA + 공유 챌린지 통합) */}
-      <section className="app-section app-reveal app-reveal-2 py-2">
-        <SectionHeader
-          title="혈통카드"
-          subtitle="랭킹 이후의 신뢰 증빙 레이어"
-          href="/bloodline-cards/create"
-          actionLabel="만들기"
-        />
-        <div className="mt-1 px-5 flex flex-col gap-3">
-          <Link
-            href="/bloodline-cards/create"
-            className="relative overflow-hidden app-card app-card-interactive block border border-white/15 bg-gradient-to-r from-slate-900 via-violet-900 to-indigo-900 p-4 text-white transition duration-200 hover:-translate-y-0.5"
-          >
-            <div className="pointer-events-none absolute inset-x-5 top-0 h-px bg-gradient-to-r from-transparent via-white/35 to-transparent" />
-            <div className="pointer-events-none absolute -left-6 -top-6 h-16 w-16 rounded-full bg-violet-300/20 blur-2xl" />
-            <div className="pointer-events-none absolute -right-8 -bottom-8 h-16 w-16 rounded-full bg-indigo-300/18 blur-2xl" />
-            <p className="app-kicker text-white/90">Bloodline Card</p>
-            <h3 className="mt-1.5 text-base font-semibold text-white">내 혈통카드 만들기</h3>
-            <p className="mt-1.5 text-xs leading-snug text-white/85">
-              대표 혈통을 공개하고 거래/보유 이력을 신뢰 레이어로 연결하세요.
-            </p>
+                ))
+              ) : (
+                <p className="text-[10px] text-slate-400">집계 준비 중</p>
+              )}
+            </div>
           </Link>
-          <div className="relative overflow-hidden rounded-3xl bg-gradient-to-br from-amber-400 via-orange-400 to-rose-500 p-4 text-white shadow-lg">
-            <div className="pointer-events-none absolute -right-4 -top-4 h-20 w-20 rounded-full bg-white/15 blur-xl" />
-            <div className="flex items-start justify-between gap-3">
-              <div className="min-w-0 flex-1">
-                <span className="inline-flex items-center gap-1 rounded-full bg-white/25 px-2 py-0.5 text-[10px] font-bold uppercase tracking-widest">
+
+          {/* 급상승 커뮤니티 */}
+          <Link
+            href={toRankingHref("community", communityPeriod)}
+            onClick={() =>
+              trackEvent(ANALYTICS_EVENTS.rankingCardClick, {
+                ranking_type: "community",
+                rank: 1,
+                entity_id: homeFeedData?.trendingPosts?.[0]?.post?.id ?? "",
+                section_id: "trending_community",
+              })
+            }
+            className="app-card app-card-interactive flex flex-col justify-between p-3 min-h-[160px]"
+          >
+            <div>
+              <div className="flex items-center justify-between">
+                <h3 className="text-sm font-bold text-slate-900">급상승 커뮤니티</h3>
+                <span className="text-[10px] text-slate-400">더보기 ›</span>
+              </div>
+              <p className="mt-0.5 text-[10px] text-slate-400">{communitySubtitle}</p>
+            </div>
+            <div className="mt-2 space-y-1.5">
+              {homeFeedData?.trendingPosts?.length ? (
+                homeFeedData.trendingPosts.slice(0, 2).map((item) => (
+                  <div key={item.post.id} className="flex items-center gap-2">
+                    <div className="min-w-0 flex-1">
+                      <p className="truncate text-xs font-medium text-slate-700">{item.post.title}</p>
+                      <p className="text-[10px] text-slate-400">#{item.rank} 상승중</p>
+                    </div>
+                  </div>
+                ))
+              ) : (
+                <p className="text-[10px] text-slate-400">급상승 글 집계 중</p>
+              )}
+            </div>
+          </Link>
+
+          {/* 무료나눔 */}
+          {homeFeedData?.freeGiveawayProducts?.length ? (
+            <Link
+              href="/products?status=판매중&price=0"
+              onClick={() =>
+                trackEvent(ANALYTICS_EVENTS.rankingCardClick, {
+                  ranking_type: "free_giveaway",
+                  rank: 1,
+                  entity_id: homeFeedData.freeGiveawayProducts[0]?.id ?? "",
+                  section_id: "free_giveaway",
+                })
+              }
+              className="app-card app-card-interactive flex flex-col justify-between p-3 min-h-[160px]"
+            >
+              <div>
+                <div className="flex items-center justify-between">
+                  <h3 className="text-sm font-bold text-slate-900">무료나눔</h3>
+                  <span className="text-[10px] text-slate-400">더보기 ›</span>
+                </div>
+                <p className="mt-0.5 text-[10px] text-slate-400">가격 0원 · 지금 연락하세요</p>
+              </div>
+              <div className="mt-2 space-y-1.5">
+                {homeFeedData.freeGiveawayProducts.slice(0, 2).map((item: FreeProductItem) => (
+                  <div key={item.id} className="flex items-center gap-2">
+                    <div className="h-8 w-8 shrink-0 overflow-hidden rounded-lg bg-slate-100">
+                      {item.photos[0] ? (
+                        <Image
+                          src={makeImageUrl(item.photos[0], "public")}
+                          alt={item.name}
+                          width={32}
+                          height={32}
+                          className="h-full w-full object-cover"
+                        />
+                      ) : null}
+                    </div>
+                    <div className="min-w-0 flex-1">
+                      <p className="truncate text-xs font-medium text-slate-700">{item.name}</p>
+                      <p className="text-[10px] text-slate-400">{item.user.name}</p>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </Link>
+          ) : (
+            <Link
+              href="/products/upload"
+              className="app-card app-card-interactive flex flex-col items-center justify-center p-3 min-h-[160px] text-center"
+            >
+              <h3 className="text-sm font-bold text-slate-900">무료나눔</h3>
+              <p className="mt-2 text-xs text-slate-500">아직 무료나눔이 없어요</p>
+              <p className="mt-1 text-[10px] font-semibold text-primary">첫 번째로 등록해보세요 ›</p>
+            </Link>
+          )}
+        </div>
+      </section>
+
+      {/* Section 4: 혈통카드 공유 챌린지 (compact) */}
+      <section className="app-section app-reveal app-reveal-2 py-2">
+        <div className="relative mx-5 overflow-hidden rounded-2xl bg-gradient-to-br from-amber-400 via-orange-400 to-rose-500 p-3 text-white shadow-lg">
+          <div className="pointer-events-none absolute -right-4 -top-4 h-16 w-16 rounded-full bg-white/15 blur-xl" />
+          <div className="flex items-center justify-between gap-3">
+            <div className="min-w-0 flex-1">
+              <div className="flex items-center gap-2">
+                <span className="inline-flex items-center rounded-full bg-white/25 px-2 py-0.5 text-[9px] font-bold uppercase tracking-widest">
                   이벤트
                 </span>
-                <h3 className="mt-2 text-base font-black leading-tight">혈통카드 공유 챌린지</h3>
-                <p className="mt-1 text-xs leading-snug text-white/90">
-                  내 혈통카드를 지인에게 선물하거나 커뮤니티에 공유해보세요.
-                  활발한 공유자에게 특별 배지가 지급됩니다!
-                </p>
+                <h3 className="text-sm font-black leading-tight">혈통카드 공유 챌린지</h3>
               </div>
+              <p className="mt-1 text-[11px] leading-snug text-white/90">
+                내 혈통카드를 공유하고 특별 배지를 받으세요!
+              </p>
             </div>
-            <div className="mt-3 flex gap-2">
+            <div className="flex shrink-0 gap-1.5">
               <Link
                 href="/bloodline-management"
                 onClick={() =>
@@ -648,83 +625,22 @@ const MainClient = ({
                     entry_type: user ? "member" : "guest",
                   })
                 }
-                className="inline-flex h-8 items-center rounded-full bg-white px-4 text-xs font-bold text-orange-600"
+                className="inline-flex h-7 items-center rounded-full bg-white px-3 text-[11px] font-bold text-orange-600"
               >
-                내 혈통카드 보기
+                보기
               </Link>
               <Link
                 href="/bloodline-cards/create"
-                className="inline-flex h-8 items-center rounded-full border border-white/40 bg-white/20 px-4 text-xs font-semibold text-white backdrop-blur-sm"
+                className="inline-flex h-7 items-center rounded-full border border-white/40 bg-white/20 px-3 text-[11px] font-semibold text-white backdrop-blur-sm"
               >
-                카드 만들기
+                만들기
               </Link>
             </div>
           </div>
         </div>
       </section>
 
-      {/* 오늘의 무료나눔 */}
-      <section className="app-section app-reveal app-reveal-3 py-2">
-        <SectionHeader
-          title="오늘의 무료나눔"
-          subtitle="가격 0원 · 지금 바로 연락해보세요"
-          href="/products?status=판매중&price=0"
-          actionLabel="더보기"
-        />
-        <div className="mt-1 px-5">
-          {homeFeedData?.freeGiveawayProducts?.length ? (
-            <div className="app-rail flex gap-3">
-              {homeFeedData.freeGiveawayProducts.map((item: FreeProductItem, index: number) => (
-                <Link
-                  key={item.id}
-                  href={`/products/${item.id}`}
-                  onClick={() =>
-                    trackEvent(ANALYTICS_EVENTS.rankingCardClick, {
-                      ranking_type: "free_giveaway",
-                      rank: index + 1,
-                      entity_id: item.id,
-                      section_id: "free_giveaway",
-                    })
-                  }
-                  className="snap-start shrink-0 w-44 app-card app-card-interactive p-3"
-                >
-                  <div className="relative h-28 w-full overflow-hidden rounded-2xl bg-slate-100">
-                    {item.photos[0] ? (
-                      <Image
-                        src={makeImageUrl(item.photos[0], "public")}
-                        alt={item.name}
-                        width={176}
-                        height={112}
-                        className="h-full w-full object-cover"
-                      />
-                    ) : null}
-                    <span className="absolute left-2 top-2 rounded-full bg-emerald-500 px-2 py-0.5 text-[10px] font-bold text-white">
-                      무료
-                    </span>
-                  </div>
-                  <div className="mt-2">
-                    <p className="line-clamp-2 text-xs font-semibold text-slate-800">{item.name}</p>
-                    <p className="mt-1 text-[11px] text-slate-500">{item.user.name}</p>
-                    <div className="mt-1 flex items-center gap-1 text-[11px] text-slate-400">
-                      <span>❤️ {item._count.favs}</span>
-                    </div>
-                  </div>
-                </Link>
-              ))}
-            </div>
-          ) : (
-            <Link
-              href="/products/upload"
-              className="app-card app-card-interactive block p-4 text-center"
-            >
-              <p className="text-sm text-slate-500">아직 무료나눔이 없어요</p>
-              <p className="mt-1 text-xs font-semibold text-primary">첫 번째로 등록해보세요 ›</p>
-            </Link>
-          )}
-        </div>
-      </section>
-
-      {/* 카테고리 탭 */}
+      {/* Section 5: 카테고리 탭 */}
       <div className="app-sticky-rail app-reveal app-reveal-3">
         <div className="px-4 py-2.5">
           <div className="app-rail flex gap-1.5 snap-none">

--- a/app/(web)/(main)/MainClient.tsx
+++ b/app/(web)/(main)/MainClient.tsx
@@ -19,7 +19,7 @@ import { ANALYTICS_EVENTS, trackEvent } from "@libs/client/analytics";
 import useUser from "hooks/useUser";
 import { toAuctionPath } from "@libs/auction-route";
 import { toPostPath } from "@libs/post-route";
-import { FreeProductItem, HotDiscussionItem, HomeFeedResponse } from "@libs/shared/ranking";
+import { FreeProductItem, HomeFeedResponse } from "@libs/shared/ranking";
 import { HomeBanner, ProductsResponse } from "@libs/shared/home";
 
 interface BeforeInstallPromptEvent extends Event {
@@ -181,9 +181,8 @@ const MainClient = ({
       "auction_ranking",
       "bloodline_ranking",
       "trending_community",
-      "bloodline_card_share",
+      "bloodline_card",
       "free_giveaway",
-      "hot_discussion",
       "personalized_home",
     ];
     sectionIds.forEach((sectionId, index) => {
@@ -604,7 +603,7 @@ const MainClient = ({
         </div>
       </section>
 
-      {/* 혈통카드 */}
+      {/* 혈통카드 (CTA + 공유 챌린지 통합) */}
       <section className="app-section app-reveal app-reveal-2 py-2">
         <SectionHeader
           title="혈통카드"
@@ -612,7 +611,7 @@ const MainClient = ({
           href="/bloodline-cards/create"
           actionLabel="만들기"
         />
-        <div className="mt-1 px-5">
+        <div className="mt-1 px-5 flex flex-col gap-3">
           <Link
             href="/bloodline-cards/create"
             className="relative overflow-hidden app-card app-card-interactive block border border-white/15 bg-gradient-to-r from-slate-900 via-violet-900 to-indigo-900 p-4 text-white transition duration-200 hover:-translate-y-0.5"
@@ -626,50 +625,46 @@ const MainClient = ({
               대표 혈통을 공개하고 거래/보유 이력을 신뢰 레이어로 연결하세요.
             </p>
           </Link>
-        </div>
-      </section>
-
-      {/* 혈통카드 공유 챌린지 */}
-      <section className="app-section app-reveal app-reveal-2 py-2">
-        <div className="relative mx-5 overflow-hidden rounded-3xl bg-gradient-to-br from-amber-400 via-orange-400 to-rose-500 p-4 text-white shadow-lg">
-          <div className="pointer-events-none absolute -right-4 -top-4 h-20 w-20 rounded-full bg-white/15 blur-xl" />
-          <div className="flex items-start justify-between gap-3">
-            <div className="min-w-0 flex-1">
-              <span className="inline-flex items-center gap-1 rounded-full bg-white/25 px-2 py-0.5 text-[10px] font-bold uppercase tracking-widest">
-                🎁 이벤트
-              </span>
-              <h3 className="mt-2 text-base font-black leading-tight">혈통카드 공유 챌린지</h3>
-              <p className="mt-1 text-xs leading-snug text-white/90">
-                내 혈통카드를 지인에게 선물하거나 커뮤니티에 공유해보세요.
-                활발한 공유자에게 특별 배지가 지급됩니다!
-              </p>
+          <div className="relative overflow-hidden rounded-3xl bg-gradient-to-br from-amber-400 via-orange-400 to-rose-500 p-4 text-white shadow-lg">
+            <div className="pointer-events-none absolute -right-4 -top-4 h-20 w-20 rounded-full bg-white/15 blur-xl" />
+            <div className="flex items-start justify-between gap-3">
+              <div className="min-w-0 flex-1">
+                <span className="inline-flex items-center gap-1 rounded-full bg-white/25 px-2 py-0.5 text-[10px] font-bold uppercase tracking-widest">
+                  이벤트
+                </span>
+                <h3 className="mt-2 text-base font-black leading-tight">혈통카드 공유 챌린지</h3>
+                <p className="mt-1 text-xs leading-snug text-white/90">
+                  내 혈통카드를 지인에게 선물하거나 커뮤니티에 공유해보세요.
+                  활발한 공유자에게 특별 배지가 지급됩니다!
+                </p>
+              </div>
             </div>
-          </div>
-          <div className="mt-3 flex gap-2">
-            <Link
-              href="/bloodline-management"
-              onClick={() =>
-                trackEvent(ANALYTICS_EVENTS.challengeJoin, {
-                  challenge_id: "bloodline_card_share",
-                  entry_type: user ? "member" : "guest",
-                })
-              }
-              className="inline-flex h-8 items-center rounded-full bg-white px-4 text-xs font-bold text-orange-600"
-            >
-              내 혈통카드 보기
-            </Link>
-            <Link
-              href="/bloodline-cards/create"
-              className="inline-flex h-8 items-center rounded-full border border-white/40 bg-white/20 px-4 text-xs font-semibold text-white backdrop-blur-sm"
-            >
-              카드 만들기
-            </Link>
+            <div className="mt-3 flex gap-2">
+              <Link
+                href="/bloodline-management"
+                onClick={() =>
+                  trackEvent(ANALYTICS_EVENTS.challengeJoin, {
+                    challenge_id: "bloodline_card_share",
+                    entry_type: user ? "member" : "guest",
+                  })
+                }
+                className="inline-flex h-8 items-center rounded-full bg-white px-4 text-xs font-bold text-orange-600"
+              >
+                내 혈통카드 보기
+              </Link>
+              <Link
+                href="/bloodline-cards/create"
+                className="inline-flex h-8 items-center rounded-full border border-white/40 bg-white/20 px-4 text-xs font-semibold text-white backdrop-blur-sm"
+              >
+                카드 만들기
+              </Link>
+            </div>
           </div>
         </div>
       </section>
 
       {/* 오늘의 무료나눔 */}
-      <section className="app-section app-reveal app-reveal-2 py-2">
+      <section className="app-section app-reveal app-reveal-3 py-2">
         <SectionHeader
           title="오늘의 무료나눔"
           subtitle="가격 0원 · 지금 바로 연락해보세요"
@@ -718,75 +713,13 @@ const MainClient = ({
               ))}
             </div>
           ) : (
-            <div className="app-card p-4 text-sm text-slate-400">
-              현재 무료나눔 상품이 없습니다. 나중에 다시 확인해보세요!
-            </div>
-          )}
-        </div>
-      </section>
-
-      {/* 실시간 HOT 토론 */}
-      <section className="app-section app-reveal app-reveal-2 py-2">
-        <SectionHeader
-          title="실시간 HOT 토론"
-          subtitle="지금 가장 뜨거운 대화 · 48시간 기준"
-          href="/posts"
-          actionLabel="더보기"
-        />
-        <div className="mt-1 px-5 flex flex-col gap-2.5">
-          {homeFeedData?.hotDiscussions?.length ? (
-            homeFeedData.hotDiscussions.map((item: HotDiscussionItem, index: number) => (
-              <Link
-                key={item.id}
-                href={toPostPath(item.id, item.title)}
-                onClick={() =>
-                  trackEvent(ANALYTICS_EVENTS.rankingCardClick, {
-                    ranking_type: "community",
-                    rank: index + 1,
-                    entity_id: item.id,
-                    section_id: "hot_discussion",
-                  })
-                }
-                className="app-card app-card-interactive flex items-start gap-3 p-3.5"
-              >
-                <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-xl bg-rose-50 text-sm font-black text-rose-500">
-                  {index + 1}
-                </div>
-                <div className="min-w-0 flex-1">
-                  <div className="flex items-center gap-1.5">
-                    {item.category ? (
-                      <span className="rounded-full bg-slate-100 px-1.5 py-0.5 text-[10px] font-medium text-slate-500">
-                        {item.category}
-                      </span>
-                    ) : null}
-                    <span className="inline-flex items-center gap-0.5 rounded-full bg-rose-100 px-1.5 py-0.5 text-[10px] font-bold text-rose-600">
-                      🔥 HOT
-                    </span>
-                  </div>
-                  <h3 className="mt-1 line-clamp-2 text-sm font-semibold text-slate-900">{item.title}</h3>
-                  <div className="mt-1.5 flex items-center gap-3 text-[11px] text-slate-500">
-                    <span>{item.user.name}</span>
-                    <span>💬 댓글 {item.commentsCount}</span>
-                    <span>👍 {item.wonderCount}</span>
-                  </div>
-                </div>
-                {item.image ? (
-                  <div className="h-14 w-14 shrink-0 overflow-hidden rounded-xl bg-slate-100">
-                    <Image
-                      src={makeImageUrl(item.image, "public")}
-                      alt={item.title}
-                      width={56}
-                      height={56}
-                      className="h-full w-full object-cover"
-                    />
-                  </div>
-                ) : null}
-              </Link>
-            ))
-          ) : (
-            <div className="app-card p-4 text-sm text-slate-400">
-              뜨거운 토론이 시작되면 여기에 표시됩니다. 먼저 글을 올려보세요!
-            </div>
+            <Link
+              href="/products/upload"
+              className="app-card app-card-interactive block p-4 text-center"
+            >
+              <p className="text-sm text-slate-500">아직 무료나눔이 없어요</p>
+              <p className="mt-1 text-xs font-semibold text-primary">첫 번째로 등록해보세요 ›</p>
+            </Link>
           )}
         </div>
       </section>

--- a/app/(web)/posts/PostsClient.tsx
+++ b/app/(web)/posts/PostsClient.tsx
@@ -22,6 +22,7 @@ import { PostsListResponse } from "pages/api/posts";
 import { TOP_LEVEL_CATEGORIES } from "@libs/categoryTaxonomy";
 import { NoticePostsResponse } from "pages/api/posts/notices";
 import { RankingResponse } from "pages/api/ranking";
+import { HotDiscussionItem } from "@libs/shared/ranking";
 
 /** 카테고리 탭 목록 */
 const TABS = [{ id: "전체", name: "전체" }, ...POST_CATEGORIES];
@@ -122,6 +123,10 @@ export default function PostsClient() {
     "/api/ranking?tab=bredy"
   );
   const { data: noticeData } = useSWR<NoticePostsResponse>("/api/posts/notices");
+  const { data: homeFeedData } = useSWR<{ hotDiscussions: HotDiscussionItem[] }>(
+    "/api/home/feed?scope=public",
+    { revalidateOnFocus: false }
+  );
   const page = useInfiniteScroll();
 
   useEffect(() => {
@@ -219,6 +224,55 @@ export default function PostsClient() {
             ))}
           </div>
         </section>
+        {/* 실시간 HOT 토론 */}
+        {homeFeedData?.hotDiscussions?.length ? (
+          <section className="app-section app-reveal app-reveal-1 py-2">
+            <SectionHeader title="실시간 HOT 토론" href="/posts" />
+            <div className="mt-1 px-4 flex flex-col gap-2.5">
+              {homeFeedData.hotDiscussions.map((item: HotDiscussionItem, index: number) => (
+                <Link
+                  key={item.id}
+                  href={toPostPath(item.id, item.title)}
+                  className="app-card app-card-interactive flex items-start gap-3 p-3.5"
+                >
+                  <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-xl bg-rose-50 text-sm font-black text-rose-500">
+                    {index + 1}
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-1.5">
+                      {item.category ? (
+                        <span className="rounded-full bg-slate-100 px-1.5 py-0.5 text-[10px] font-medium text-slate-500">
+                          {item.category}
+                        </span>
+                      ) : null}
+                      <span className="inline-flex items-center gap-0.5 rounded-full bg-rose-100 px-1.5 py-0.5 text-[10px] font-bold text-rose-600">
+                        HOT
+                      </span>
+                    </div>
+                    <h3 className="mt-1 line-clamp-2 text-sm font-semibold text-slate-900">{item.title}</h3>
+                    <div className="mt-1.5 flex items-center gap-3 text-[11px] text-slate-500">
+                      <span>{item.user.name}</span>
+                      <span>댓글 {item.commentsCount}</span>
+                      <span>좋아요 {item.wonderCount}</span>
+                    </div>
+                  </div>
+                  {item.image ? (
+                    <div className="h-14 w-14 shrink-0 overflow-hidden rounded-xl bg-slate-100">
+                      <Image
+                        src={makeImageUrl(item.image, "public")}
+                        alt={item.title}
+                        width={56}
+                        height={56}
+                        className="h-full w-full object-cover"
+                      />
+                    </div>
+                  ) : null}
+                </Link>
+              ))}
+            </div>
+          </section>
+        ) : null}
+
         {/* TOP 브리디 */}
         <section className="app-section app-reveal app-reveal-3 py-2">
           <SectionHeader title="TOP 브리디" href="/ranking" />

--- a/app/(web)/posts/PostsClient.tsx
+++ b/app/(web)/posts/PostsClient.tsx
@@ -35,11 +35,13 @@ type SortType = (typeof SORT_TABS)[number]["id"];
 
 const CATEGORY_ACCENT: Record<string, string> = {
   전체: "bg-slate-500",
-  사진: "bg-slate-500",
-  변이: "bg-slate-500",
-  사육: "bg-slate-500",
-  질문: "bg-slate-500",
-  자유: "bg-slate-500",
+  자유: "bg-emerald-500",
+  질문: "bg-blue-500",
+  정보: "bg-amber-500",
+  자랑: "bg-pink-500",
+  후기: "bg-violet-500",
+  사진: "bg-cyan-500",
+  변이: "bg-rose-500",
 };
 
 const NOTICE_BANNERS = [
@@ -85,26 +87,11 @@ const BACKUP_COMMUNITY_CONTENT: BackupCommunityContent[] = [
   },
 ];
 
-const SectionHeader = ({
-  title,
-  href,
-}: {
-  title: string;
-  href: string;
-}) => (
-  <div className="px-4 flex items-center justify-between">
-    <h2 className="app-section-title">{title}</h2>
-    <Link href={href} className="app-section-link">
-      더보기
-      <span aria-hidden="true">›</span>
-    </Link>
-  </div>
-);
-
 export default function PostsClient() {
   const [selectedCategory, setSelectedCategory] = useState("전체");
   const [selectedSort, setSelectedSort] = useState<SortType>("latest");
   const [selectedSpecies, setSelectedSpecies] = useState("전체");
+  const [activeHighlightTab, setActiveHighlightTab] = useState<"hot" | "breeder">("hot");
 
   const getKey = (
     pageIndex: number,
@@ -132,6 +119,13 @@ export default function PostsClient() {
   useEffect(() => {
     setSize(page);
   }, [setSize, page]);
+
+  // Default to "breeder" tab if hotDiscussions is empty
+  useEffect(() => {
+    if (homeFeedData && (!homeFeedData.hotDiscussions || homeFeedData.hotDiscussions.length === 0)) {
+      setActiveHighlightTab("breeder");
+    }
+  }, [homeFeedData]);
 
   // 카테고리 변경 시 데이터 리셋
   const handleCategoryChange = (categoryId: string) => {
@@ -177,7 +171,7 @@ export default function PostsClient() {
   return (
     <Layout icon hasTabBar seoTitle="반려생활" showSearch>
       <div className="app-page flex flex-col h-full">
-        {/* 공지/고정 게시글 */}
+        {/* 1. 공지사항 */}
         <section className="px-4 py-3 space-y-2 app-reveal">
           <div className="flex items-center justify-between pb-1">
             <h2 className="app-section-title">공지사항</h2>
@@ -204,199 +198,203 @@ export default function PostsClient() {
           ))}
         </section>
 
+        {/* 2. 글 카테고리 탭 (primary - scrollable) */}
+        <div className="app-rail flex gap-1.5 px-4 py-2">
+          {TABS.map((tab) => (
+            <button
+              key={tab.id}
+              onClick={() => handleCategoryChange(tab.id)}
+              className={cn(
+                "shrink-0 rounded-full px-3 py-1.5 text-sm font-medium transition-colors",
+                selectedCategory === tab.id
+                  ? "bg-slate-900 text-white"
+                  : "bg-slate-100 text-slate-500"
+              )}
+            >
+              <span className={cn("mr-1 inline-block h-2 w-2 rounded-full", CATEGORY_ACCENT[tab.id] ?? "bg-slate-400")} />
+              {tab.name}
+            </button>
+          ))}
+        </div>
 
-        <section className="px-4 pb-2 app-reveal">
-          <div className="flex items-center gap-2 overflow-x-auto pb-1">
-            {[{ id: "전체", name: "전체" }, ...TOP_LEVEL_CATEGORIES].map((species) => (
-              <button
-                key={species.id}
-                type="button"
-                onClick={() => handleSpeciesChange(species.id)}
-                className={cn(
-                  "shrink-0 rounded-full border px-3 py-1 text-xs font-medium transition-colors",
-                  selectedSpecies === species.id
-                    ? "border-primary bg-primary text-white"
-                    : "border-slate-200 bg-white text-slate-500"
-                )}
-              >
-                {species.name}
-              </button>
+        {/* 3. 종 필터 + 정렬 드롭다운 (secondary - compact row) */}
+        <div className="flex items-center gap-2 px-4 py-1.5">
+          <select
+            value={selectedSpecies}
+            onChange={(e) => handleSpeciesChange(e.target.value)}
+            className="h-8 rounded-lg border border-slate-200 bg-white px-2.5 text-xs font-medium text-slate-600"
+          >
+            <option value="전체">전체 종</option>
+            {TOP_LEVEL_CATEGORIES.map((s) => (
+              <option key={s.id} value={s.id}>{s.name}</option>
             ))}
-          </div>
-        </section>
-        {/* 실시간 HOT 토론 */}
-        {homeFeedData?.hotDiscussions?.length ? (
-          <section className="app-section app-reveal app-reveal-1 py-2">
-            <SectionHeader title="실시간 HOT 토론" href="/posts" />
-            <div className="mt-1 px-4 flex flex-col gap-2.5">
-              {homeFeedData.hotDiscussions.map((item: HotDiscussionItem, index: number) => (
-                <Link
-                  key={item.id}
-                  href={toPostPath(item.id, item.title)}
-                  className="app-card app-card-interactive flex items-start gap-3 p-3.5"
-                >
-                  <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-xl bg-rose-50 text-sm font-black text-rose-500">
-                    {index + 1}
-                  </div>
-                  <div className="min-w-0 flex-1">
-                    <div className="flex items-center gap-1.5">
-                      {item.category ? (
-                        <span className="rounded-full bg-slate-100 px-1.5 py-0.5 text-[10px] font-medium text-slate-500">
-                          {item.category}
-                        </span>
-                      ) : null}
-                      <span className="inline-flex items-center gap-0.5 rounded-full bg-rose-100 px-1.5 py-0.5 text-[10px] font-bold text-rose-600">
-                        HOT
-                      </span>
-                    </div>
-                    <h3 className="mt-1 line-clamp-2 text-sm font-semibold text-slate-900">{item.title}</h3>
-                    <div className="mt-1.5 flex items-center gap-3 text-[11px] text-slate-500">
-                      <span>{item.user.name}</span>
-                      <span>댓글 {item.commentsCount}</span>
-                      <span>좋아요 {item.wonderCount}</span>
-                    </div>
-                  </div>
-                  {item.image ? (
-                    <div className="h-14 w-14 shrink-0 overflow-hidden rounded-xl bg-slate-100">
-                      <Image
-                        src={makeImageUrl(item.image, "public")}
-                        alt={item.title}
-                        width={56}
-                        height={56}
-                        className="h-full w-full object-cover"
-                      />
-                    </div>
-                  ) : null}
-                </Link>
-              ))}
-            </div>
-          </section>
-        ) : null}
+          </select>
+          <select
+            value={selectedSort}
+            onChange={(e) => handleSortChange(e.target.value as SortType)}
+            className="h-8 rounded-lg border border-slate-200 bg-white px-2.5 text-xs font-medium text-slate-600"
+          >
+            {SORT_TABS.map((s) => (
+              <option key={s.id} value={s.id}>{s.name}</option>
+            ))}
+          </select>
+        </div>
 
-        {/* TOP 브리디 */}
-        <section className="app-section app-reveal app-reveal-3 py-2">
-          <SectionHeader title="TOP 브리디" href="/ranking" />
-          <div className="app-rail mt-2 flex gap-2.5 px-4">
-            {bredyData ? (
-              bredyRanking.length > 0 ? (
-                bredyRanking.map((bredy, index) => (
-                  <Link
-                    key={bredy.user.id}
-                    href={`/profiles/${bredy.user.id}`}
-                    className="snap-start shrink-0 w-40 app-card app-card-interactive px-2.5 py-2"
-                  >
-                    <div className="flex items-center justify-between">
-                      {index < 3 ? (
-                        <span className="text-xs leading-none">
-                          {index === 0 ? "🥇" : index === 1 ? "🥈" : "🥉"}
-                        </span>
-                      ) : (
-                        <span className="app-caption text-[11px] font-semibold text-slate-500">
-                          {index + 1}위
-                        </span>
-                      )}
-                      <span className="app-caption text-[11px]">점수</span>
-                    </div>
-                    <div className="mt-2 flex items-center gap-2">
-                      {bredy.user.avatar ? (
-                        <Image
-                          src={makeImageUrl(bredy.user.avatar, "avatar")}
-                          className="w-7 h-7 rounded-full object-cover"
-                          width={36}
-                          height={36}
-                          alt=""
-                        />
-                      ) : (
-                        <div className="w-7 h-7 rounded-full bg-slate-200" />
-                      )}
-                      <div className="min-w-0">
-                        <p className="text-sm font-semibold tracking-tight text-slate-900 truncate">
-                          {bredy.user.name}
-                        </p>
-                        <p className="app-caption text-[11px]">
-                          ❤️ {bredy.totalLikes}
-                        </p>
+        {/* 4. Tabbed section: HOT 토론 / TOP 브리디 */}
+        <section className="app-section py-2">
+          <div className="flex items-center gap-1 px-4">
+            <button
+              onClick={() => setActiveHighlightTab("hot")}
+              className={cn(
+                "rounded-full px-3 py-1.5 text-sm font-semibold transition-colors",
+                activeHighlightTab === "hot"
+                  ? "bg-rose-500 text-white"
+                  : "bg-slate-100 text-slate-500"
+              )}
+            >
+              🔥 HOT 토론
+            </button>
+            <button
+              onClick={() => setActiveHighlightTab("breeder")}
+              className={cn(
+                "rounded-full px-3 py-1.5 text-sm font-semibold transition-colors",
+                activeHighlightTab === "breeder"
+                  ? "bg-amber-500 text-white"
+                  : "bg-slate-100 text-slate-500"
+              )}
+            >
+              🏆 TOP 브리디
+            </button>
+          </div>
+          <div className="mt-2">
+            {activeHighlightTab === "hot" ? (
+              /* HOT 토론 content */
+              homeFeedData?.hotDiscussions?.length ? (
+                <div className="px-4 flex flex-col gap-2.5">
+                  {homeFeedData.hotDiscussions.map((item: HotDiscussionItem, index: number) => (
+                    <Link
+                      key={item.id}
+                      href={toPostPath(item.id, item.title)}
+                      className="app-card app-card-interactive flex items-start gap-3 p-3.5"
+                    >
+                      <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-xl bg-rose-50 text-sm font-black text-rose-500">
+                        {index + 1}
                       </div>
-                    </div>
-                    <p className="mt-2 text-sm font-bold text-primary">
-                      {bredy.score.toLocaleString()}
-                    </p>
-                  </Link>
-                ))
+                      <div className="min-w-0 flex-1">
+                        <div className="flex items-center gap-1.5">
+                          {item.category ? (
+                            <span className="rounded-full bg-slate-100 px-1.5 py-0.5 text-[10px] font-medium text-slate-500">
+                              {item.category}
+                            </span>
+                          ) : null}
+                          <span className="inline-flex items-center gap-0.5 rounded-full bg-rose-100 px-1.5 py-0.5 text-[10px] font-bold text-rose-600">
+                            HOT
+                          </span>
+                        </div>
+                        <h3 className="mt-1 line-clamp-2 text-sm font-semibold text-slate-900">{item.title}</h3>
+                        <div className="mt-1.5 flex items-center gap-3 text-[11px] text-slate-500">
+                          <span>{item.user.name}</span>
+                          <span>댓글 {item.commentsCount}</span>
+                          <span>좋아요 {item.wonderCount}</span>
+                        </div>
+                      </div>
+                      {item.image ? (
+                        <div className="h-14 w-14 shrink-0 overflow-hidden rounded-xl bg-slate-100">
+                          <Image
+                            src={makeImageUrl(item.image, "public")}
+                            alt={item.title}
+                            width={56}
+                            height={56}
+                            className="h-full w-full object-cover"
+                          />
+                        </div>
+                      ) : null}
+                    </Link>
+                  ))}
+                </div>
               ) : (
-                <div className="app-body-sm text-slate-400 px-1 py-2">
-                  표시할 브리디 랭킹이 없습니다.
+                <div className="app-body-sm text-slate-400 px-5 py-4">
+                  실시간 HOT 토론이 없습니다.
                 </div>
               )
             ) : (
-              [...Array(3)].map((_, i) => (
-                <div
-                  key={i}
-                  className="snap-start shrink-0 w-40 app-card px-2.5 py-2 animate-pulse"
-                >
-                  <div className="h-4 bg-slate-200 rounded w-1/4" />
-                  <div className="mt-2 flex items-center gap-2">
-                    <div className="w-7 h-7 rounded-full bg-slate-200" />
-                    <div className="space-y-1 flex-1">
-                      <div className="h-3 bg-slate-200 rounded w-2/3" />
-                      <div className="h-3 bg-slate-200 rounded w-1/3" />
+              /* TOP 브리디 content */
+              <div className="app-rail flex gap-2.5 px-4">
+                {bredyData ? (
+                  bredyRanking.length > 0 ? (
+                    bredyRanking.map((bredy, index) => (
+                      <Link
+                        key={bredy.user.id}
+                        href={`/profiles/${bredy.user.id}`}
+                        className="snap-start shrink-0 w-72 app-card app-card-interactive px-2.5 py-2"
+                      >
+                        <div className="flex items-center justify-between">
+                          {index < 3 ? (
+                            <span className="text-xs leading-none">
+                              {index === 0 ? "🥇" : index === 1 ? "🥈" : "🥉"}
+                            </span>
+                          ) : (
+                            <span className="app-caption text-[11px] font-semibold text-slate-500">
+                              {index + 1}위
+                            </span>
+                          )}
+                          <span className="app-caption text-[11px]">점수</span>
+                        </div>
+                        <div className="mt-2 flex items-center gap-2">
+                          {bredy.user.avatar ? (
+                            <Image
+                              src={makeImageUrl(bredy.user.avatar, "avatar")}
+                              className="w-7 h-7 rounded-full object-cover"
+                              width={36}
+                              height={36}
+                              alt=""
+                            />
+                          ) : (
+                            <div className="w-7 h-7 rounded-full bg-slate-200" />
+                          )}
+                          <div className="min-w-0">
+                            <p className="text-sm font-semibold tracking-tight text-slate-900 truncate">
+                              {bredy.user.name}
+                            </p>
+                            <p className="app-caption text-[11px]">
+                              ❤️ {bredy.totalLikes}
+                            </p>
+                          </div>
+                        </div>
+                        <p className="mt-2 text-sm font-bold text-primary">
+                          {bredy.score.toLocaleString()}
+                        </p>
+                      </Link>
+                    ))
+                  ) : (
+                    <div className="app-body-sm text-slate-400 px-1 py-2">
+                      표시할 브리디 랭킹이 없습니다.
                     </div>
-                  </div>
-                  <div className="mt-2 h-4 bg-slate-200 rounded w-1/2" />
-                </div>
-              ))
+                  )
+                ) : (
+                  [...Array(3)].map((_, i) => (
+                    <div
+                      key={i}
+                      className="snap-start shrink-0 w-72 app-card px-2.5 py-2 animate-pulse"
+                    >
+                      <div className="h-4 bg-slate-200 rounded w-1/4" />
+                      <div className="mt-2 flex items-center gap-2">
+                        <div className="w-7 h-7 rounded-full bg-slate-200" />
+                        <div className="space-y-1 flex-1">
+                          <div className="h-3 bg-slate-200 rounded w-2/3" />
+                          <div className="h-3 bg-slate-200 rounded w-1/3" />
+                        </div>
+                      </div>
+                      <div className="mt-2 h-4 bg-slate-200 rounded w-1/2" />
+                    </div>
+                  ))
+                )}
+              </div>
             )}
           </div>
         </section>
 
-        {/* 카테고리 탭 */}
-        <div className="app-sticky-rail app-reveal-fade">
-          <div className="px-4 py-3">
-            <div className="app-card p-2">
-              <div className="app-rail flex gap-2 snap-none">
-                {SORT_TABS.map((tab) => (
-                  <button
-                    key={tab.id}
-                    onClick={() => handleSortChange(tab.id)}
-                    className={cn(
-                      "app-chip",
-                      selectedSort === tab.id
-                        ? "app-chip-active"
-                        : "app-chip-muted"
-                    )}
-                  >
-                    {tab.name}
-                  </button>
-                ))}
-              </div>
-              <div className="app-rail flex gap-2 snap-none mt-2">
-                {TABS.map((tab) => (
-                  <button
-                    key={tab.id}
-                    onClick={() => handleCategoryChange(tab.id)}
-                    className={cn(
-                      "app-chip",
-                      selectedCategory === tab.id
-                        ? "app-chip-active"
-                        : "app-chip-muted"
-                    )}
-                  >
-                    <span
-                      className={cn(
-                        "w-2 h-2 rounded-full",
-                        selectedCategory === tab.id
-                          ? "bg-white/90"
-                          : CATEGORY_ACCENT[tab.id] ?? "bg-slate-400"
-                      )}
-                    />
-                    {tab.name}
-                  </button>
-                ))}
-              </div>
-            </div>
-          </div>
-        </div>
-
+        {/* 5. 게시글 목록 title + count */}
         <section id="all-posts" className="px-4 pt-6 pb-2">
           <div className="flex items-end justify-between">
             <div>
@@ -411,7 +409,7 @@ export default function PostsClient() {
           </div>
         </section>
 
-        {/* 게시글 목록 */}
+        {/* 6. 게시글 목록 (infinite scroll) */}
         <div className="border-y border-slate-100 bg-white pb-4">
           {data ? (
             sortedPosts.map((post) => (
@@ -592,7 +590,7 @@ export default function PostsClient() {
           )}
         </div>
 
-        {/* 글쓰기 버튼 */}
+        {/* 7. 글쓰기 버튼 */}
         <FloatingButton href="/posts/upload">
           <svg
             className="w-6 h-6"

--- a/app/(web)/posts/PostsClient.tsx
+++ b/app/(web)/posts/PostsClient.tsx
@@ -47,7 +47,9 @@ const DropdownSelect = ({
   ariaLabel: string;
 }) => {
   const [open, setOpen] = useState(false);
+  const [focusedIndex, setFocusedIndex] = useState(-1);
   const ref = useRef<HTMLDivElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
   const selectedLabel = options.find((o) => o.value === value)?.label ?? value;
 
   useEffect(() => {
@@ -58,12 +60,59 @@ const DropdownSelect = ({
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, []);
 
+  useEffect(() => {
+    if (open) {
+      setFocusedIndex(options.findIndex((o) => o.value === value));
+    }
+  }, [open, options, value]);
+
+  useEffect(() => {
+    if (open && focusedIndex >= 0 && listRef.current) {
+      const items = listRef.current.querySelectorAll("[role='option']");
+      (items[focusedIndex] as HTMLElement)?.scrollIntoView({ block: "nearest" });
+    }
+  }, [focusedIndex, open]);
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (!open) {
+      if (e.key === "ArrowDown" || e.key === "ArrowUp" || e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        setOpen(true);
+      }
+      return;
+    }
+    switch (e.key) {
+      case "Escape":
+        e.preventDefault();
+        setOpen(false);
+        break;
+      case "ArrowDown":
+        e.preventDefault();
+        setFocusedIndex((prev) => (prev + 1) % options.length);
+        break;
+      case "ArrowUp":
+        e.preventDefault();
+        setFocusedIndex((prev) => (prev - 1 + options.length) % options.length);
+        break;
+      case "Enter":
+      case " ":
+        e.preventDefault();
+        if (focusedIndex >= 0) {
+          onChange(options[focusedIndex].value);
+          setOpen(false);
+        }
+        break;
+    }
+  };
+
   return (
     <div ref={ref} className="relative">
       <button
         type="button"
         aria-label={ariaLabel}
         aria-expanded={open}
+        aria-haspopup="listbox"
+        onKeyDown={handleKeyDown}
         onClick={() => setOpen((prev) => !prev)}
         className={cn(
           "flex h-8 items-center gap-1 rounded-full border px-3 text-xs font-medium transition-colors",
@@ -78,20 +127,29 @@ const DropdownSelect = ({
         </svg>
       </button>
       {open && (
-        <div className="absolute left-0 top-full z-30 mt-1 min-w-[120px] overflow-hidden rounded-xl border border-slate-200 bg-white py-1 shadow-lg">
-          {options.map((option) => (
+        <div
+          ref={listRef}
+          role="listbox"
+          aria-label={ariaLabel}
+          className="absolute left-0 top-full z-30 mt-1 min-w-[120px] max-h-[240px] overflow-y-auto overflow-hidden rounded-xl border border-slate-200 bg-white py-1 shadow-lg"
+        >
+          {options.map((option, index) => (
             <button
               key={option.value}
               type="button"
+              role="option"
+              aria-selected={value === option.value}
               onClick={() => {
                 onChange(option.value);
                 setOpen(false);
               }}
+              onMouseEnter={() => setFocusedIndex(index)}
               className={cn(
                 "flex w-full items-center px-3 py-2 text-left text-xs transition-colors",
                 value === option.value
                   ? "bg-slate-50 font-semibold text-slate-900"
-                  : "text-slate-600 hover:bg-slate-50"
+                  : "text-slate-600",
+                focusedIndex === index && value !== option.value && "bg-slate-50"
               )}
             >
               {value === option.value && (
@@ -343,7 +401,7 @@ export default function PostsClient() {
                   : "bg-slate-100 text-slate-500"
               )}
             >
-              🔥 HOT 토론
+              <span aria-hidden="true">🔥</span> HOT 토론
             </button>
             <button
               role="tab"
@@ -360,14 +418,18 @@ export default function PostsClient() {
                   : "bg-slate-100 text-slate-500"
               )}
             >
-              🏆 TOP 브리디
+              <span aria-hidden="true">🏆</span> TOP 브리디
             </button>
           </div>
           <div className="mt-2">
-            {activeHighlightTab === "hot" ? (
-              /* HOT 토론 content */
-              homeFeedData?.hotDiscussions?.length ? (
-                <div id="highlight-panel-hot" role="tabpanel" className="px-4 flex flex-col gap-2.5">
+            {/* HOT 토론 panel */}
+            <div
+              id="highlight-panel-hot"
+              role="tabpanel"
+              hidden={activeHighlightTab !== "hot"}
+            >
+              {homeFeedData?.hotDiscussions?.length ? (
+                <div className="px-4 flex flex-col gap-2.5">
                   {homeFeedData.hotDiscussions.map((item: HotDiscussionItem, index: number) => (
                     <Link
                       key={item.id}
@@ -419,8 +481,8 @@ export default function PostsClient() {
                   ))}
                 </div>
               ) : (
-                <div id="highlight-panel-hot" role="tabpanel" className="mx-4 rounded-2xl border-2 border-dashed border-slate-200 bg-slate-50/60 px-5 py-6 text-center dark:border-slate-700 dark:bg-slate-800/40">
-                  <p className="text-2xl">💬</p>
+                <div className="mx-4 rounded-2xl border-2 border-dashed border-slate-200 bg-slate-50/60 px-5 py-6 text-center dark:border-slate-700 dark:bg-slate-800/40">
+                  <p className="text-2xl"><span role="img" aria-label="말풍선">💬</span></p>
                   <p className="mt-2 text-sm font-semibold text-slate-700 dark:text-slate-200">
                     아직 실시간 HOT 토론이 없어요
                   </p>
@@ -437,10 +499,16 @@ export default function PostsClient() {
                     토론 만들기
                   </Link>
                 </div>
-              )
-            ) : (
-              /* TOP 브리디 content */
-              <div id="highlight-panel-breeder" role="tabpanel" className="app-rail flex gap-2.5 px-4">
+              )}
+            </div>
+
+            {/* TOP 브리디 panel */}
+            <div
+              id="highlight-panel-breeder"
+              role="tabpanel"
+              hidden={activeHighlightTab !== "breeder"}
+            >
+              <div className="app-rail flex gap-2.5 px-4">
                 {bredyData ? (
                   bredyRanking.length > 0 ? (
                     bredyRanking.map((bredy, index) => (
@@ -519,7 +587,7 @@ export default function PostsClient() {
                   ))
                 )}
               </div>
-            )}
+            </div>
           </div>
         </section>
 

--- a/app/(web)/posts/PostsClient.tsx
+++ b/app/(web)/posts/PostsClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
 import Image from "@components/atoms/Image";
 import {
@@ -33,6 +33,80 @@ const SORT_TABS = [
   { id: "comments", name: "댓글순" },
 ];
 type SortType = (typeof SORT_TABS)[number]["id"];
+
+/** 커스텀 드롭다운 셀렉트 */
+const DropdownSelect = ({
+  value,
+  onChange,
+  options,
+  ariaLabel,
+}: {
+  value: string;
+  onChange: (value: string) => void;
+  options: { value: string; label: string }[];
+  ariaLabel: string;
+}) => {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  const selectedLabel = options.find((o) => o.value === value)?.label ?? value;
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        type="button"
+        aria-label={ariaLabel}
+        aria-expanded={open}
+        onClick={() => setOpen((prev) => !prev)}
+        className={cn(
+          "flex h-8 items-center gap-1 rounded-full border px-3 text-xs font-medium transition-colors",
+          open
+            ? "border-slate-900 bg-slate-900 text-white"
+            : "border-slate-200 bg-white text-slate-600 hover:border-slate-300"
+        )}
+      >
+        {selectedLabel}
+        <svg className={cn("h-3 w-3 transition-transform", open && "rotate-180")} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M19 9l-7 7-7-7" />
+        </svg>
+      </button>
+      {open && (
+        <div className="absolute left-0 top-full z-30 mt-1 min-w-[120px] overflow-hidden rounded-xl border border-slate-200 bg-white py-1 shadow-lg">
+          {options.map((option) => (
+            <button
+              key={option.value}
+              type="button"
+              onClick={() => {
+                onChange(option.value);
+                setOpen(false);
+              }}
+              className={cn(
+                "flex w-full items-center px-3 py-2 text-left text-xs transition-colors",
+                value === option.value
+                  ? "bg-slate-50 font-semibold text-slate-900"
+                  : "text-slate-600 hover:bg-slate-50"
+              )}
+            >
+              {value === option.value && (
+                <svg className="mr-1.5 h-3 w-3 text-slate-900" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2.5" d="M5 13l4 4L19 7" />
+                </svg>
+              )}
+              {option.label}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
 
 const CATEGORY_ACCENT: Record<string, string> = {
   전체: "bg-slate-500",
@@ -234,27 +308,21 @@ export default function PostsClient() {
 
         {/* 3. 종 필터 + 정렬 드롭다운 (secondary - compact row) */}
         <div className="flex items-center gap-2 px-4 py-1.5">
-          <select
+          <DropdownSelect
             value={selectedSpecies}
-            onChange={(e) => handleSpeciesChange(e.target.value)}
-            aria-label="종 필터"
-            className="h-8 rounded-lg border border-slate-200 bg-white px-2.5 text-xs font-medium text-slate-600"
-          >
-            <option value="전체">전체 종</option>
-            {TOP_LEVEL_CATEGORIES.map((s) => (
-              <option key={s.id} value={s.id}>{s.name}</option>
-            ))}
-          </select>
-          <select
+            onChange={handleSpeciesChange}
+            ariaLabel="종 필터"
+            options={[
+              { value: "전체", label: "전체 종" },
+              ...TOP_LEVEL_CATEGORIES.map((s) => ({ value: s.id, label: s.name })),
+            ]}
+          />
+          <DropdownSelect
             value={selectedSort}
-            onChange={(e) => handleSortChange(e.target.value as SortType)}
-            aria-label="정렬 기준"
-            className="h-8 rounded-lg border border-slate-200 bg-white px-2.5 text-xs font-medium text-slate-600"
-          >
-            {SORT_TABS.map((s) => (
-              <option key={s.id} value={s.id}>{s.name}</option>
-            ))}
-          </select>
+            onChange={(v) => handleSortChange(v as SortType)}
+            ariaLabel="정렬 기준"
+            options={SORT_TABS.map((s) => ({ value: s.id, label: s.name }))}
+          />
         </div>
 
         {/* 4. Tabbed section: HOT 토론 / TOP 브리디 */}

--- a/app/(web)/posts/PostsClient.tsx
+++ b/app/(web)/posts/PostsClient.tsx
@@ -18,6 +18,7 @@ import { useInfiniteScroll } from "hooks/useInfiniteScroll";
 import { cn, getTimeAgoString, makeImageUrl } from "@libs/client/utils";
 import { toPostPath } from "@libs/post-route";
 import { POST_CATEGORIES } from "@libs/constants";
+import { ANALYTICS_EVENTS, trackEvent } from "@libs/client/analytics";
 import { PostsListResponse } from "pages/api/posts";
 import { TOP_LEVEL_CATEGORIES } from "@libs/categoryTaxonomy";
 import { NoticePostsResponse } from "pages/api/posts/notices";
@@ -129,16 +130,28 @@ export default function PostsClient() {
 
   // 카테고리 변경 시 데이터 리셋
   const handleCategoryChange = (categoryId: string) => {
+    trackEvent(ANALYTICS_EVENTS.postsCategorySelected, {
+      selected_category: categoryId,
+      previous_category: selectedCategory,
+    });
     setSelectedCategory(categoryId);
     setSize(1);
   };
   const handleSortChange = (sortType: SortType) => {
     if (selectedSort === sortType) return;
+    trackEvent(ANALYTICS_EVENTS.postsSortChanged, {
+      selected_sort: sortType,
+      previous_sort: selectedSort,
+    });
     setSelectedSort(sortType);
     setSize(1);
   };
 
   const handleSpeciesChange = (species: string) => {
+    trackEvent(ANALYTICS_EVENTS.postsSpeciesChanged, {
+      selected_species: species,
+      previous_species: selectedSpecies,
+    });
     setSelectedSpecies(species);
     setSize(1);
   };
@@ -147,13 +160,13 @@ export default function PostsClient() {
   const noticePosts = noticeData?.posts ?? [];
   const displayNotices =
     noticePosts.length > 0
-      ? noticePosts.slice(0, 2).map((post) => ({
+      ? noticePosts.slice(0, 1).map((post) => ({
           id: `notice-${post.id}`,
           label: "공지",
           title: post.title,
           href: toPostPath(post.id, post.title),
         }))
-      : NOTICE_BANNERS.map((notice) => ({
+      : NOTICE_BANNERS.slice(0, 1).map((notice) => ({
           id: notice.id,
           label: notice.label,
           title: notice.title,
@@ -199,10 +212,12 @@ export default function PostsClient() {
         </section>
 
         {/* 2. 글 카테고리 탭 (primary - scrollable) */}
-        <div className="app-rail flex gap-1.5 px-4 py-2">
+        <div className="app-rail flex gap-1.5 px-4 py-2" role="tablist" aria-label="글 카테고리">
           {TABS.map((tab) => (
             <button
               key={tab.id}
+              role="tab"
+              aria-selected={selectedCategory === tab.id}
               onClick={() => handleCategoryChange(tab.id)}
               className={cn(
                 "shrink-0 rounded-full px-3 py-1.5 text-sm font-medium transition-colors",
@@ -222,6 +237,7 @@ export default function PostsClient() {
           <select
             value={selectedSpecies}
             onChange={(e) => handleSpeciesChange(e.target.value)}
+            aria-label="종 필터"
             className="h-8 rounded-lg border border-slate-200 bg-white px-2.5 text-xs font-medium text-slate-600"
           >
             <option value="전체">전체 종</option>
@@ -232,6 +248,7 @@ export default function PostsClient() {
           <select
             value={selectedSort}
             onChange={(e) => handleSortChange(e.target.value as SortType)}
+            aria-label="정렬 기준"
             className="h-8 rounded-lg border border-slate-200 bg-white px-2.5 text-xs font-medium text-slate-600"
           >
             {SORT_TABS.map((s) => (
@@ -242,9 +259,15 @@ export default function PostsClient() {
 
         {/* 4. Tabbed section: HOT 토론 / TOP 브리디 */}
         <section className="app-section py-2">
-          <div className="flex items-center gap-1 px-4">
+          <div className="flex items-center gap-1 px-4" role="tablist" aria-label="하이라이트 탭">
             <button
-              onClick={() => setActiveHighlightTab("hot")}
+              role="tab"
+              aria-selected={activeHighlightTab === "hot"}
+              aria-controls="highlight-panel-hot"
+              onClick={() => {
+                trackEvent(ANALYTICS_EVENTS.postsHighlightTabChanged, { tab: "hot" });
+                setActiveHighlightTab("hot");
+              }}
               className={cn(
                 "rounded-full px-3 py-1.5 text-sm font-semibold transition-colors",
                 activeHighlightTab === "hot"
@@ -255,7 +278,13 @@ export default function PostsClient() {
               🔥 HOT 토론
             </button>
             <button
-              onClick={() => setActiveHighlightTab("breeder")}
+              role="tab"
+              aria-selected={activeHighlightTab === "breeder"}
+              aria-controls="highlight-panel-breeder"
+              onClick={() => {
+                trackEvent(ANALYTICS_EVENTS.postsHighlightTabChanged, { tab: "breeder" });
+                setActiveHighlightTab("breeder");
+              }}
               className={cn(
                 "rounded-full px-3 py-1.5 text-sm font-semibold transition-colors",
                 activeHighlightTab === "breeder"
@@ -270,11 +299,20 @@ export default function PostsClient() {
             {activeHighlightTab === "hot" ? (
               /* HOT 토론 content */
               homeFeedData?.hotDiscussions?.length ? (
-                <div className="px-4 flex flex-col gap-2.5">
+                <div id="highlight-panel-hot" role="tabpanel" className="px-4 flex flex-col gap-2.5">
                   {homeFeedData.hotDiscussions.map((item: HotDiscussionItem, index: number) => (
                     <Link
                       key={item.id}
                       href={toPostPath(item.id, item.title)}
+                      onClick={() =>
+                        trackEvent(ANALYTICS_EVENTS.postsHotDiscussionClicked, {
+                          post_id: item.id,
+                          post_title: item.title,
+                          rank_index: index + 1,
+                          comments_count: item.commentsCount,
+                          wonder_count: item.wonderCount,
+                        })
+                      }
                       className="app-card app-card-interactive flex items-start gap-3 p-3.5"
                     >
                       <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-xl bg-rose-50 text-sm font-black text-rose-500">
@@ -313,19 +351,42 @@ export default function PostsClient() {
                   ))}
                 </div>
               ) : (
-                <div className="app-body-sm text-slate-400 px-5 py-4">
-                  실시간 HOT 토론이 없습니다.
+                <div id="highlight-panel-hot" role="tabpanel" className="mx-4 rounded-2xl border-2 border-dashed border-slate-200 bg-slate-50/60 px-5 py-6 text-center dark:border-slate-700 dark:bg-slate-800/40">
+                  <p className="text-2xl">💬</p>
+                  <p className="mt-2 text-sm font-semibold text-slate-700 dark:text-slate-200">
+                    아직 실시간 HOT 토론이 없어요
+                  </p>
+                  <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">
+                    첫 번째 토론의 주인공이 되어보세요!
+                  </p>
+                  <Link
+                    href="/posts/upload"
+                    className="mt-3 inline-flex items-center gap-1 rounded-full bg-rose-500 px-4 py-2 text-xs font-semibold text-white shadow-sm transition-colors hover:bg-rose-600"
+                  >
+                    <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 4v16m8-8H4" />
+                    </svg>
+                    토론 만들기
+                  </Link>
                 </div>
               )
             ) : (
               /* TOP 브리디 content */
-              <div className="app-rail flex gap-2.5 px-4">
+              <div id="highlight-panel-breeder" role="tabpanel" className="app-rail flex gap-2.5 px-4">
                 {bredyData ? (
                   bredyRanking.length > 0 ? (
                     bredyRanking.map((bredy, index) => (
                       <Link
                         key={bredy.user.id}
                         href={`/profiles/${bredy.user.id}`}
+                        onClick={() =>
+                          trackEvent(ANALYTICS_EVENTS.postsBreederTabClicked, {
+                            breeder_id: bredy.user.id,
+                            breeder_name: bredy.user.name,
+                            rank_index: index + 1,
+                            score: bredy.score,
+                          })
+                        }
                         className="snap-start shrink-0 w-72 app-card app-card-interactive px-2.5 py-2"
                       >
                         <div className="flex items-center justify-between">

--- a/app/(web)/posts/upload/UploadClient.tsx
+++ b/app/(web)/posts/upload/UploadClient.tsx
@@ -27,6 +27,7 @@ interface UploadPostMutation {
   post: Post;
   error?: string;
   message?: string;
+  status?: number;
 }
 
 type SubmitStep = "idle" | "image" | "submit";
@@ -113,7 +114,7 @@ const UploadClient = () => {
         },
       });
 
-      if ((result as any).status === 401) {
+      if (result.status === 401) {
         toast.error("로그인이 필요합니다.");
         router.push(`/auth/login?next=${encodeURIComponent("/posts/upload")}`);
         return;

--- a/app/(web)/posts/upload/UploadClient.tsx
+++ b/app/(web)/posts/upload/UploadClient.tsx
@@ -113,6 +113,12 @@ const UploadClient = () => {
         },
       });
 
+      if ((result as any).status === 401) {
+        toast.error("로그인이 필요합니다.");
+        router.push(`/auth/login?next=${encodeURIComponent("/posts/upload")}`);
+        return;
+      }
+
       if (result.success && result.post?.id) {
         toast.success("게시글이 등록되었습니다.");
         router.push(toPostPath(result.post.id, result.post.title));

--- a/app/(web)/posts/upload/page.tsx
+++ b/app/(web)/posts/upload/page.tsx
@@ -1,5 +1,7 @@
 import React from "react";
 import UploadClient from "./UploadClient";
+import { getSessionUser } from "@libs/server/getUser";
+import { redirect } from "next/navigation";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
@@ -15,7 +17,11 @@ export const metadata: Metadata = {
   description: "로그인 사용자 전용 게시글 업로드 페이지입니다.",
 };
 
-const page = () => {
+const page = async () => {
+  const user = await getSessionUser();
+  if (!user) {
+    redirect("/auth/login?next=/posts/upload");
+  }
   return <UploadClient />;
 };
 

--- a/libs/client/analytics.ts
+++ b/libs/client/analytics.ts
@@ -38,6 +38,13 @@ export const ANALYTICS_EVENTS = {
   rankingCardClick: "ranking_card_click",
   challengeJoin: "challenge_join",
   shareCardExport: "share_card_export",
+  // 반려생활 (PostsClient) 이벤트
+  postsCategorySelected: "posts_category_selected",
+  postsSortChanged: "posts_sort_changed",
+  postsSpeciesChanged: "posts_species_changed",
+  postsHotDiscussionClicked: "posts_hot_discussion_clicked",
+  postsBreederTabClicked: "posts_breeder_tab_clicked",
+  postsHighlightTabChanged: "posts_highlight_tab_changed",
   sentryExampleClientErrorClicked: "sentry_example_client_error_clicked",
   sentryExampleApiErrorClicked: "sentry_example_api_error_clicked",
   sentryExampleApiErrorReceived: "sentry_example_api_error_received",

--- a/libs/server/home.ts
+++ b/libs/server/home.ts
@@ -8,6 +8,8 @@ import {
   getAuctionRanking,
   getBloodlineRanking,
   getBreederRanking,
+  getFreeGiveawayProducts,
+  getHotDiscussions,
   getMyRankingSummary,
   getTrendingCommunityPosts,
 } from "@libs/server/ranking";
@@ -63,6 +65,8 @@ const SAMPLE_HOME_FEED: HomeFeedResponse = {
   myRanking: null,
   myMissionSummary: [],
   currentSeasonId: null,
+  freeGiveawayProducts: [],
+  hotDiscussions: [],
 };
 
 type HomeFeedOptions = {
@@ -114,6 +118,8 @@ const buildHomeFeed = async ({
     recentTrendingPosts,
     myRanking,
     myMissionSummary,
+    freeGiveawayProducts,
+    hotDiscussions,
   ] = await Promise.all([
     getBreederRanking({ limit: 10, period: "weekly", userId: resolvedUserId }),
     getAuctionRanking({ periodScope: "week", limit: 20 }),
@@ -121,6 +127,8 @@ const buildHomeFeed = async ({
     getTrendingCommunityPosts({ limit: 6, window: "24h" }),
     resolvedUserId ? getMyRankingSummary(resolvedUserId) : Promise.resolve(null),
     resolvedUserId ? getUserMissionSummary(resolvedUserId) : Promise.resolve([]),
+    getFreeGiveawayProducts({ limit: 6 }),
+    getHotDiscussions({ limit: 5 }),
   ]);
 
   const [
@@ -189,6 +197,8 @@ const buildHomeFeed = async ({
     myRanking,
     myMissionSummary,
     currentSeasonId: season.id,
+    freeGiveawayProducts,
+    hotDiscussions,
   };
 };
 

--- a/libs/server/home.ts
+++ b/libs/server/home.ts
@@ -118,6 +118,8 @@ const buildHomeFeed = async ({
     recentTrendingPosts,
     myRanking,
     myMissionSummary,
+    freeGiveawayProducts,
+    hotDiscussions,
   ] = await Promise.all([
     getBreederRanking({ limit: 10, period: "weekly", userId: resolvedUserId }),
     getAuctionRanking({ periodScope: "week", limit: 20 }),
@@ -125,6 +127,8 @@ const buildHomeFeed = async ({
     getTrendingCommunityPosts({ limit: 6, window: "24h" }),
     resolvedUserId ? getMyRankingSummary(resolvedUserId) : Promise.resolve(null),
     resolvedUserId ? getUserMissionSummary(resolvedUserId) : Promise.resolve([]),
+    getFreeGiveawayProducts({ limit: 6 }),
+    getHotDiscussions({ limit: 5 }),
   ]);
 
   const [
@@ -145,12 +149,6 @@ const buildHomeFeed = async ({
     recentTrendingPosts.length > 0
       ? Promise.resolve(recentTrendingPosts)
       : getTrendingCommunityPosts({ limit: 6, window: "all" }),
-  ]);
-
-  // 보조 콘텐츠는 핵심 랭킹과 별도 배치로 실행
-  const [freeGiveawayProducts, hotDiscussions] = await Promise.all([
-    getFreeGiveawayProducts({ limit: 6 }),
-    getHotDiscussions({ limit: 5 }),
   ]);
 
   const heroBreederMode = weeklyBreeders.length > 0 ? "weekly" : "all";

--- a/libs/server/home.ts
+++ b/libs/server/home.ts
@@ -118,8 +118,6 @@ const buildHomeFeed = async ({
     recentTrendingPosts,
     myRanking,
     myMissionSummary,
-    freeGiveawayProducts,
-    hotDiscussions,
   ] = await Promise.all([
     getBreederRanking({ limit: 10, period: "weekly", userId: resolvedUserId }),
     getAuctionRanking({ periodScope: "week", limit: 20 }),
@@ -127,8 +125,6 @@ const buildHomeFeed = async ({
     getTrendingCommunityPosts({ limit: 6, window: "24h" }),
     resolvedUserId ? getMyRankingSummary(resolvedUserId) : Promise.resolve(null),
     resolvedUserId ? getUserMissionSummary(resolvedUserId) : Promise.resolve([]),
-    getFreeGiveawayProducts({ limit: 6 }),
-    getHotDiscussions({ limit: 5 }),
   ]);
 
   const [
@@ -149,6 +145,12 @@ const buildHomeFeed = async ({
     recentTrendingPosts.length > 0
       ? Promise.resolve(recentTrendingPosts)
       : getTrendingCommunityPosts({ limit: 6, window: "all" }),
+  ]);
+
+  // 보조 콘텐츠는 핵심 랭킹과 별도 배치로 실행
+  const [freeGiveawayProducts, hotDiscussions] = await Promise.all([
+    getFreeGiveawayProducts({ limit: 6 }),
+    getHotDiscussions({ limit: 5 }),
   ]);
 
   const heroBreederMode = weeklyBreeders.length > 0 ? "weekly" : "all";

--- a/libs/server/ranking.ts
+++ b/libs/server/ranking.ts
@@ -5,6 +5,8 @@ import {
   BloodlineRankingItem,
   BreederRankingItem,
   CommunityWindow,
+  FreeProductItem,
+  HotDiscussionItem,
   RankingMeSummary,
   RankingPeriod,
   SeasonBadgeItem,
@@ -596,4 +598,88 @@ export const getMyRankingSummary = async (userId: number): Promise<RankingMeSumm
     scoreDelta: me.scoreDelta,
     badges: me.badges,
   };
+};
+
+export const getFreeGiveawayProducts = async ({
+  limit = 6,
+}: { limit?: number } = {}): Promise<FreeProductItem[]> => {
+  const products = await client.product.findMany({
+    where: {
+      price: 0,
+      status: "판매중",
+      isDeleted: false,
+      isHidden: false,
+    },
+    select: {
+      id: true,
+      name: true,
+      photos: true,
+      category: true,
+      createdAt: true,
+      user: {
+        select: { id: true, name: true, avatar: true },
+      },
+      _count: {
+        select: { favs: true },
+      },
+    },
+    orderBy: { createdAt: "desc" },
+    take: limit,
+  });
+
+  return products.map((p) => ({
+    ...p,
+    createdAt: p.createdAt.toISOString(),
+  }));
+};
+
+export const getHotDiscussions = async ({
+  limit = 5,
+}: { limit?: number } = {}): Promise<HotDiscussionItem[]> => {
+  const windowStart = new Date(Date.now() - 48 * 60 * 60 * 1000);
+
+  const posts = await client.post.findMany({
+    where: {
+      category: { in: ["질문", "자유", "정보"] },
+      createdAt: { gte: windowStart },
+      user: { status: "ACTIVE" },
+    },
+    select: {
+      id: true,
+      title: true,
+      description: true,
+      image: true,
+      category: true,
+      createdAt: true,
+      _count: {
+        select: { comments: true, Likes: true },
+      },
+      user: {
+        select: { id: true, name: true, avatar: true },
+      },
+    },
+    orderBy: [{ comments: { _count: "desc" } }, { createdAt: "desc" }],
+    take: limit * 3,
+  });
+
+  return posts
+    .filter((p) => p._count.comments > 0 || p._count.Likes > 0)
+    .sort(
+      (a, b) =>
+        b._count.comments * 2 +
+        b._count.Likes -
+        (a._count.comments * 2 + a._count.Likes)
+    )
+    .slice(0, limit)
+    .map((p) => ({
+      id: p.id,
+      title: p.title,
+      description: p.description,
+      image: p.image,
+      category: p.category,
+      createdAt: p.createdAt.toISOString(),
+      commentsCount: p._count.comments,
+      wonderCount: p._count.Likes,
+      user: p.user,
+    }));
 };

--- a/libs/shared/ranking.ts
+++ b/libs/shared/ranking.ts
@@ -123,7 +123,7 @@ export interface HotDiscussionItem {
   id: number;
   title: string;
   description: string;
-  image: string | null;
+  image: string;
   category: string | null;
   createdAt: string;
   commentsCount: number;

--- a/libs/shared/ranking.ts
+++ b/libs/shared/ranking.ts
@@ -105,6 +105,36 @@ export interface RankingMeSummary {
   badges: SeasonBadgeItem[];
 }
 
+export interface FreeProductItem {
+  id: number;
+  name: string;
+  photos: string[];
+  category: string | null;
+  createdAt: string;
+  user: {
+    id: number;
+    name: string;
+    avatar: string | null;
+  };
+  _count: { favs: number };
+}
+
+export interface HotDiscussionItem {
+  id: number;
+  title: string;
+  description: string;
+  image: string | null;
+  category: string | null;
+  createdAt: string;
+  commentsCount: number;
+  wonderCount: number;
+  user: {
+    id: number;
+    name: string;
+    avatar: string | null;
+  };
+}
+
 export interface HomeFeedResponse {
   success: boolean;
   heroBreeder: BreederRankingItem | null;
@@ -118,4 +148,6 @@ export interface HomeFeedResponse {
   myRanking: RankingMeSummary | null;
   myMissionSummary: MissionProgressItem[];
   currentSeasonId: number | null;
+  freeGiveawayProducts: FreeProductItem[];
+  hotDiscussions: HotDiscussionItem[];
 }

--- a/next.config.js
+++ b/next.config.js
@@ -25,6 +25,36 @@ const nextConfig = {
     // PPR 활성화 시 ISR과 함께 사용되어 더 빠른 페이지 로딩 제공
     // ppr: true, // 안정화 버전에서 활성화 고려
   },
+  webpack(config) {
+    // @svgr/webpack: turbopack.rules에서는 이미 설정되어 있지만
+    // webpack 모드에서도 SVG를 React 컴포넌트로 import할 수 있도록 설정
+    const fileLoaderRule = config.module.rules.find((rule) =>
+      rule.test?.test?.(".svg")
+    );
+
+    config.module.rules.push(
+      // *.svg?url → 기존 file-loader 적용 (이미지 URL로 사용)
+      {
+        ...fileLoaderRule,
+        test: /\.svg$/i,
+        resourceQuery: /url/,
+      },
+      // 그 외 *.svg → React 컴포넌트로 변환
+      {
+        test: /\.svg$/i,
+        issuer: fileLoaderRule.issuer,
+        resourceQuery: {
+          not: [...(fileLoaderRule.resourceQuery?.not || []), /url/],
+        },
+        use: ["@svgr/webpack"],
+      }
+    );
+
+    // 기존 file-loader에서 SVG 제외 (위에서 별도 처리)
+    fileLoaderRule.exclude = /\.svg$/i;
+
+    return config;
+  },
   // 캐싱 최적화: onDemandEntries 설정
   // 개발 모드에서도 페이지를 메모리에 유지하는 시간 설정
   onDemandEntries: {

--- a/pages/api/home/feed.ts
+++ b/pages/api/home/feed.ts
@@ -41,6 +41,8 @@ async function handler(
       myRanking: null,
       myMissionSummary: [],
       currentSeasonId: null,
+      freeGiveawayProducts: [],
+      hotDiscussions: [],
     });
   }
 }

--- a/pages/api/posts/index.ts
+++ b/pages/api/posts/index.ts
@@ -136,6 +136,12 @@ const handler = async (
       session: { user },
     } = req;
 
+    if (!user?.id) {
+      return res
+        .status(401)
+        .json({ success: false, error: "로그인이 필요합니다." });
+    }
+
     if (String(category) === "공지") {
       const dbUser = user?.id
         ? await client.user.findUnique({

--- a/test-bypass.txt
+++ b/test-bypass.txt
@@ -1,1 +1,0 @@
-bypass test

--- a/test-bypass.txt
+++ b/test-bypass.txt
@@ -1,0 +1,1 @@
+bypass test


### PR DESCRIPTION
## Summary

GitHub Issue #108 "반려생활에 재밌는 요소 많이 추가하기" 요청에 따라 홈 화면과 반려생활 페이지에 다양한 기능을 추가하고, 코드 품질 개선 및 버그 수정을 진행합니다.

### 홈 화면 개선
- **혈통카드 공유 챌린지 배너** — TOP 브리더 섹션 위로 이동, 오렌지/로즈 그라데이션 이벤트 배너
- **오늘의 무료나눔** — 가격 0원 상품을 가로 스크롤 카드로 표시
- **실시간 HOT 토론** — 48시간 이내 활발한 커뮤니티 글 표시
- **TOP 브리더 카드 리디자인** — 다크 네이비 → 미니멀 화이트 카드 스타일, 4열 통계 바(게시/댓글/입찰/낙찰)
- **2x2 그리드 카드** — 불필요한 공백 제거, 항목 2개로 축소

### 반려생활 페이지 개선
- **카테고리 필터 탭** — WAI-ARIA `role="tablist/tab"`, `aria-selected` 접근성 적용
- **HOT토론/TOP브리디 탭 전환** — `hidden` 속성으로 탭 패널 유지, aria-controls 유효성 보장
- **커스텀 DropdownSelect** — 키보드 내비게이션(Escape/ArrowUp/ArrowDown/Enter), `role="listbox/option"`
- **빈 상태 CTA** — HOT 토론 없을 때 "토론 만들기" 버튼 표시
- **PostHog 애널리틱스** — 카테고리/정렬/종 선택, 탭 전환, 클릭 이벤트 추적

### 코드 품질 & 버그 수정
- **LoginClient SVG 렌더 에러 수정** — webpack 모드에서 `@svgr/webpack` 설정 추가, "Element type is invalid" 에러 해결
- **게시글 작성 401 처리** — 미인증 사용자 POST 요청 시 로그인 페이지로 리다이렉트
- **타입 안전성** — `(result as any).status` → `status?: number` 인터페이스 추가
- **DB 성능** — `freeGiveawayProducts`/`hotDiscussions` 쿼리를 `Promise.all` 배치로 병합
- **접근성** — 이모지에 `aria-hidden`, DropdownSelect 키보드 내비게이션
- **README** — 절대경로 → 상대경로 수정
- **미사용 코드 제거** — 불필요한 import, dead function 삭제

### 백엔드 변경
- `libs/server/ranking.ts` — `getFreeGiveawayProducts()`, `getHotDiscussions()` 추가
- `libs/shared/ranking.ts` — `FreeProductItem`, `HotDiscussionItem` 타입 추가
- `libs/server/home.ts` — Promise.all 배치 최적화
- `pages/api/posts/index.ts` — 미인증 POST 401 가드 추가
- `next.config.js` — webpack SVG 룰 추가 (`@svgr/webpack`)

## Test plan
- [x] 홈 화면 새 섹션 3개 렌더링 확인
- [x] TOP 브리더 카드 리디자인 확인
- [x] 반려생활 카테고리 탭 전환 동작
- [x] HOT토론/TOP브리디 탭 전환 동작
- [x] 커스텀 DropdownSelect 키보드 내비게이션
- [x] 로그인 페이지 SVG 아이콘 정상 렌더링 (webpack 모드)
- [x] 미인증 게시글 작성 시 로그인 리다이렉트
- [x] 브라우저 테스트 11/11 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)