### PR TITLE
HOT 토론 기준 및 로그인 화면 분기 정리

### DIFF
--- a/app/(web)/posts/PostsClient.tsx
+++ b/app/(web)/posts/PostsClient.tsx
@@ -484,7 +484,7 @@ export default function PostsClient() {
                 <div className="mx-4 rounded-2xl border-2 border-dashed border-slate-200 bg-slate-50/60 px-5 py-6 text-center dark:border-slate-700 dark:bg-slate-800/40">
                   <p className="text-2xl"><span role="img" aria-label="말풍선">💬</span></p>
                   <p className="mt-2 text-sm font-semibold text-slate-700 dark:text-slate-200">
-                    아직 실시간 HOT 토론이 없어요
+                    아직 HOT 토론이 없어요
                   </p>
                   <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">
                     첫 번째 토론의 주인공이 되어보세요!

--- a/app/auth/login/LoginClient.tsx
+++ b/app/auth/login/LoginClient.tsx
@@ -97,6 +97,20 @@ type LoginClientProps = {
   shouldShowTestLogin: boolean;
 };
 
+const isReactNativeWebViewWindow = () => {
+  if (typeof window === "undefined") return false;
+
+  const reactNativeWebView = (
+    window as typeof window & {
+      ReactNativeWebView?: {
+        postMessage?: (message: string) => void;
+      };
+    }
+  ).ReactNativeWebView;
+
+  return typeof reactNativeWebView?.postMessage === "function";
+};
+
 const LoginClient = ({ shouldShowTestLogin }: LoginClientProps) => {
   const searchParams = useSearchParams();
   const [login] = useMutation<LoginResponseType>("/api/auth/login");
@@ -110,9 +124,12 @@ const LoginClient = ({ shouldShowTestLogin }: LoginClientProps) => {
   const [isLoadingTestAccounts, setIsLoadingTestAccounts] = useState(false);
   const [testLoginError, setTestLoginError] = useState("");
   const [switchingTestUserId, setSwitchingTestUserId] = useState<number | null>(null);
+  const [isReactNativeWebView, setIsReactNativeWebView] = useState(false);
   // 기본값은 노출(true). 추후 숨길 때 NEXT_PUBLIC_ENABLE_GOOGLE_LOGIN=false로 설정.
   const shouldShowGoogleLogin =
     process.env.NEXT_PUBLIC_ENABLE_GOOGLE_LOGIN !== "false";
+  const canShowGoogleLogin =
+    shouldShowGoogleLogin && !isReactNativeWebView;
 
   /**카카오로그인 */
   const loginWithKakao = () => {
@@ -175,6 +192,10 @@ const LoginClient = ({ shouldShowTestLogin }: LoginClientProps) => {
       "https://t1.kakaocdn.net/kakao_js_sdk/2.7.2/kakao.min.js",
       "kakao"
     );
+  }, []);
+
+  useEffect(() => {
+    setIsReactNativeWebView(isReactNativeWebViewWindow());
   }, []);
 
   useEffect(() => {
@@ -312,7 +333,7 @@ const LoginClient = ({ shouldShowTestLogin }: LoginClientProps) => {
           {/* <KakaoLogin className="absolute left-7" width={26} height={26} /> */}
           <span className="title-3">{"카카오로 계속하기"}</span>
         </button>
-        {shouldShowGoogleLogin ? (
+        {canShowGoogleLogin ? (
           <button
             onClick={() => loginWithGoogle()}
             className="button relative flex h-[54px] w-full items-center justify-center rounded-lg border border-Gray-300 bg-white px-7 py-[14px]"
@@ -320,11 +341,11 @@ const LoginClient = ({ shouldShowTestLogin }: LoginClientProps) => {
             <GoogleRound className="absolute left-7" width={26} height={26} />
             <span className="title-3">{"구글로 계속하기"}</span>
           </button>
-        ) : (
+        ) : !isReactNativeWebView ? (
           <p className="mt-1 text-[11px] text-Gray-500">
             현재는 카카오 로그인만 지원합니다.
           </p>
-        )}
+        ) : null}
         {shouldShowTestLogin ? (
           <div className="w-full rounded-lg border border-Gray-200 bg-Gray-50 p-3">
             <p className="text-[11px] text-Gray-500">테스트 로그인 (개발/테스트 환경 전용)</p>

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -13,6 +13,7 @@ export default defineConfig([
   },
   globalIgnores([
     ".next/**",
+    ".claude/worktrees/**",
     "out/**",
     "build/**",
     "next-env.d.ts",

--- a/jest.config.js
+++ b/jest.config.js
@@ -71,6 +71,12 @@ module.exports = {
   ],
 
   // 로컬 worktree 복제본은 테스트 스캔에서 제외
-  modulePathIgnorePatterns: ["<rootDir>/.worktrees/"],
-  testPathIgnorePatterns: ["<rootDir>/.worktrees/"],
+  modulePathIgnorePatterns: [
+    "<rootDir>/.worktrees/",
+    "<rootDir>/.claude/worktrees/",
+  ],
+  testPathIgnorePatterns: [
+    "<rootDir>/.worktrees/",
+    "<rootDir>/.claude/worktrees/",
+  ],
 };

--- a/libs/server/ranking.ts
+++ b/libs/server/ranking.ts
@@ -636,12 +636,9 @@ export const getFreeGiveawayProducts = async ({
 export const getHotDiscussions = async ({
   limit = 5,
 }: { limit?: number } = {}): Promise<HotDiscussionItem[]> => {
-  const windowStart = new Date(Date.now() - 48 * 60 * 60 * 1000);
-
   const posts = await client.post.findMany({
     where: {
       category: { in: ["질문", "자유", "정보"] },
-      createdAt: { gte: windowStart },
       user: { status: "ACTIVE" },
     },
     select: {


### PR DESCRIPTION
### 개요

게시글 화면의 HOT 토론이 최근 48시간 제한 때문에 쉽게 비어 보이던 동작을 완화했습니다.
또한 React Native WebView로 로그인 화면이 열릴 때 구글 로그인 버튼이 노출되지 않도록 분기했고, 로컬 `.claude/worktrees` 복제본이 lint/jest 스캔에 포함되어 검증이 흔들리던 문제를 정리했습니다.

### 변경 유형

- [ ] 버그 수정
- [ ] 새로운 기능 추가
- [x] 기존 기능 수정
- [x] 스타일 수정
- [x] 기타(문서 수정, 리팩토링 등)

### 주요 변경사항

- HOT 토론 조회에서 48시간 생성 제한을 제거했습니다.
- HOT 빈 상태 문구를 `실시간 HOT 토론`에서 `HOT 토론`으로 정리했습니다.
- React Native WebView 환경에서는 구글 로그인 버튼을 숨기도록 로그인 화면 분기를 추가했습니다.
- ESLint/Jest가 `.claude/worktrees`를 스캔하지 않도록 검증 범위를 조정했습니다.

---

### 관련 태스크 / 이슈

- 별도 Jira/이슈 링크 없음

### 테스트

- `npm run verify:ci`
- HOT 토론 조회 로직 변경 및 로그인 화면 분기에 따른 기존 유틸/컴포넌트 테스트 통과 확인

### 리스크 / 참고

- `app/(web)/bloodline-cards/create/BloodlineCardCreateClient.tsx`에 기존 `@next/next/no-img-element` 경고 1건이 남아 있습니다.
- `app/(web)/posts/PostsClient.tsx` 내부에는 기존 px 기반 Tailwind 유틸이 남아 있으나, 이번 diff에서 새로 추가된 항목은 아닙니다.
- `app/auth/login/LoginClient.tsx` 내부에는 기존 `console.log` 2건과 px 기반 Tailwind 유틸이 남아 있습니다. 이번 요청에서는 동작 분기만 반영했습니다.

### 스크린샷

- 없음
