### PR TITLE
style: 경매와 혈통카드 UI 정리

### DIFF
--- a/app/(web)/auctions/AuctionsClient.tsx
+++ b/app/(web)/auctions/AuctionsClient.tsx
@@ -60,7 +60,7 @@ export default function AuctionsClient() {
 
   const getKey = (
     pageIndex: number,
-    previousPageData: AuctionsListResponse | null
+    previousPageData: AuctionsListResponse | null,
   ) => {
     if (previousPageData && !previousPageData.auctions.length) return null;
     const statusParam =
@@ -74,10 +74,17 @@ export default function AuctionsClient() {
     const queryParam = searchQuery
       ? `&q=${encodeURIComponent(searchQuery)}`
       : "";
-    return `/api/auctions?page=${pageIndex + 1}${statusParam}${categoryParam}${queryParam}`;
+    return `/api/auctions?page=${
+      pageIndex + 1
+    }${statusParam}${categoryParam}${queryParam}`;
   };
 
-  const { data, setSize, mutate } = useSWRInfinite<AuctionsListResponse>(getKey);
+  const {
+    data,
+    error: auctionsError,
+    setSize,
+    mutate,
+  } = useSWRInfinite<AuctionsListResponse>(getKey);
   const page = useInfiniteScroll();
 
   useEffect(() => {
@@ -100,115 +107,99 @@ export default function AuctionsClient() {
 
   return (
     <Layout icon hasTabBar seoTitle="경매" showSearch>
-      <div className="flex flex-col h-full">
-        <div className="px-4 pt-3 pb-2">
-          <div className="overflow-hidden rounded-2xl border border-slate-200 bg-white dark:border-slate-700 dark:bg-slate-900">
-            <div className="px-4 py-4">
-              <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-                <div>
-                  <p className="text-[11px] font-semibold uppercase tracking-[0.12em] text-slate-500 dark:text-slate-400">
-                    Bredy Auction
-                  </p>
-                  <h1 className="mt-1 text-xl font-black tracking-[-0.02em] text-slate-900 dark:text-slate-50">
-                    카페/밴드 링크형 경매
-                  </h1>
-                  <p className="mt-1.5 text-xs leading-relaxed text-slate-600 dark:text-slate-300">
-                    카카오 로그인 기반 참여, 자동 연장, 입찰 검증으로
-                    경매 운영 리스크를 줄였습니다.
-                  </p>
-                </div>
-                <div className="flex shrink-0 flex-wrap items-center gap-1.5">
-                  <Link
-                    href="/auctions/create"
-                    className="inline-flex h-8 items-center whitespace-nowrap rounded-full bg-gradient-to-r from-amber-300 to-orange-300 px-3.5 text-[11px] font-bold text-slate-900 shadow-[0_6px_14px_rgba(251,146,60,0.28)] transition hover:brightness-95"
-                  >
-                    1분만에 경매 생성하기
-                  </Link>
-                  <Link
-                    href="/auction-tool"
-                    className="inline-flex h-8 items-center rounded-full bg-slate-900 px-3 text-[11px] font-semibold text-white transition-colors hover:bg-slate-800 dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-slate-200"
-                  >
-                    도구 소개
-                  </Link>
-                  <Link
-                    href="/auctions/rules"
-                    className="inline-flex h-8 items-center rounded-full border border-slate-300 bg-white px-3 text-[11px] font-semibold text-slate-700 transition-colors hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700"
-                  >
-                    운영 룰
-                  </Link>
-                </div>
-              </div>
-
-              <div className="mt-3 grid grid-cols-1 gap-2 sm:grid-cols-3">
-                <article className="rounded-lg border border-slate-200 bg-slate-50 px-3 py-2.5 dark:border-slate-700 dark:bg-slate-800">
-                  <p className="text-[10px] font-semibold text-slate-500 dark:text-slate-400">입찰 검증</p>
-                  <p className="mt-0.5 text-[12px] font-bold text-slate-800 dark:text-slate-100">호가 단위 자동 검증</p>
-                </article>
-                <article className="rounded-lg border border-slate-200 bg-slate-50 px-3 py-2.5 dark:border-slate-700 dark:bg-slate-800">
-                  <p className="text-[10px] font-semibold text-slate-500 dark:text-slate-400">마감 정책</p>
-                  <p className="mt-0.5 text-[12px] font-bold text-slate-800 dark:text-slate-100">마감 임박 시 자동 연장</p>
-                </article>
-                <article className="rounded-lg border border-slate-200 bg-slate-50 px-3 py-2.5 dark:border-slate-700 dark:bg-slate-800">
-                  <p className="text-[10px] font-semibold text-slate-500 dark:text-slate-400">운영 정책</p>
-                  <p className="mt-0.5 text-[12px] font-bold text-slate-800 dark:text-slate-100">신고/위반 계정 참여 제한</p>
-                </article>
-              </div>
-
-              <form onSubmit={handleSearchSubmit} className="mt-3 flex items-center gap-2">
-                <input
-                  value={searchInput}
-                  onChange={(event) => setSearchInput(event.target.value)}
-                  placeholder="경매 매물 검색 (제목/설명/판매자)"
-                  className="h-9 w-full rounded-lg border border-slate-200 bg-white px-3 text-sm text-slate-900 outline-none transition placeholder:text-slate-400 focus:border-slate-400 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100 dark:placeholder:text-slate-500 dark:focus:border-slate-500"
-                />
-                <button
-                  type="submit"
-                  className="inline-flex h-9 shrink-0 items-center rounded-lg bg-slate-900 px-3 text-xs font-semibold text-white transition-colors hover:bg-slate-800"
-                >
-                  검색
-                </button>
-                {(searchInput || searchQuery) && (
-                  <button
-                    type="button"
-                    onClick={handleSearchReset}
-                    className="inline-flex h-9 shrink-0 items-center rounded-lg border border-slate-200 bg-white px-2.5 text-xs font-medium text-slate-600 transition-colors hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700"
-                  >
-                    초기화
-                  </button>
-                )}
-              </form>
+      <div className="flex h-full flex-col">
+        <section className="border-b border-slate-200 bg-white px-4 py-4 dark:border-slate-800 dark:bg-slate-950">
+          <div className="flex flex-col gap-3">
+            <div>
+              <p className="text-[12px] font-semibold text-primary">
+                Bredy Auction
+              </p>
+              <h1 className="mt-1 text-[21px] font-bold tracking-[-0.02em] text-slate-950 dark:text-slate-50">
+                진행 중인 경매
+              </h1>
+              <p className="mt-1 text-[13px] leading-relaxed text-slate-500 dark:text-slate-400">
+                링크 공유, 자동 연장, 입찰 검증을 한 화면에서 확인하세요.
+              </p>
             </div>
+
+            <div className="flex flex-wrap items-center gap-2">
+              <Link
+                href="/auctions/create"
+                className="inline-flex h-9 items-center whitespace-nowrap rounded-lg bg-slate-900 px-3.5 text-xs font-semibold text-white transition-colors hover:bg-slate-800 dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-slate-200"
+              >
+                경매 등록
+              </Link>
+              <Link
+                href="/auction-tool"
+                className="inline-flex h-9 items-center rounded-lg border border-slate-200 bg-white px-3 text-xs font-semibold text-slate-700 transition-colors hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200 dark:hover:bg-slate-800"
+              >
+                도구 소개
+              </Link>
+              <Link
+                href="/auctions/rules"
+                className="inline-flex h-9 items-center rounded-lg border border-slate-200 bg-white px-3 text-xs font-semibold text-slate-700 transition-colors hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200 dark:hover:bg-slate-800"
+              >
+                운영 룰
+              </Link>
+            </div>
+
+            <form
+              onSubmit={handleSearchSubmit}
+              className="flex items-center gap-2"
+            >
+              <input
+                value={searchInput}
+                onChange={(event) => setSearchInput(event.target.value)}
+                placeholder="제목, 설명, 판매자 검색"
+                className="h-10 w-full rounded-lg border border-slate-200 bg-slate-50 px-3 text-sm text-slate-900 outline-none transition placeholder:text-slate-400 focus:border-slate-400 focus:bg-white dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100 dark:placeholder:text-slate-500 dark:focus:border-slate-500"
+              />
+              <button
+                type="submit"
+                className="inline-flex h-10 shrink-0 items-center rounded-lg bg-slate-900 px-3.5 text-xs font-semibold text-white transition-colors hover:bg-slate-800 dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-slate-200"
+              >
+                검색
+              </button>
+              {(searchInput || searchQuery) && (
+                <button
+                  type="button"
+                  onClick={handleSearchReset}
+                  className="inline-flex h-10 shrink-0 items-center rounded-lg border border-slate-200 bg-white px-3 text-xs font-medium text-slate-600 transition-colors hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-300 dark:hover:bg-slate-800"
+                >
+                  초기화
+                </button>
+              )}
+            </form>
           </div>
-        </div>
+        </section>
 
         {/* 상태 탭 */}
-        <div className="sticky top-14 z-10 border-b border-gray-100 bg-white/80 backdrop-blur-sm dark:border-slate-800 dark:bg-slate-900/85">
-          <div className="flex overflow-x-auto scrollbar-hide px-4 pt-3 gap-2">
+        <div className="sticky top-14 z-10 border-b border-slate-200 bg-white/95 backdrop-blur-sm dark:border-slate-800 dark:bg-slate-950/95">
+          <div className="flex gap-2 overflow-x-auto px-4 pt-3 scrollbar-hide">
             {CATEGORY_TABS.map((tab) => (
               <button
                 key={tab.id}
                 onClick={() => setSelectedCategory(tab.id)}
                 className={cn(
-                  "flex-shrink-0 px-3 py-1.5 rounded-full text-xs font-medium transition-colors whitespace-nowrap",
+                  "flex-shrink-0 whitespace-nowrap rounded-lg border px-3 py-1.5 text-xs font-semibold transition-colors",
                   selectedCategory === tab.id
-                    ? "bg-slate-200 text-slate-900 dark:bg-slate-100 dark:text-slate-900"
-                    : "bg-slate-100 text-slate-600 hover:bg-slate-200 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700"
+                    ? "border-slate-900 bg-slate-900 text-white dark:border-slate-100 dark:bg-slate-100 dark:text-slate-900"
+                    : "border-slate-200 bg-white text-slate-600 hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-300 dark:hover:bg-slate-800",
                 )}
               >
                 {tab.name}
               </button>
             ))}
           </div>
-          <div className="flex overflow-x-auto scrollbar-hide px-4 py-3 gap-2">
+          <div className="flex gap-2 overflow-x-auto px-4 py-3 scrollbar-hide">
             {STATUS_TABS.map((tab) => (
               <button
                 key={tab.id}
                 onClick={() => setSelectedStatus(tab.id)}
                 className={cn(
-                  "flex-shrink-0 px-4 py-2 rounded-full text-sm font-medium transition-colors whitespace-nowrap",
+                  "flex-shrink-0 whitespace-nowrap rounded-lg border px-4 py-2 text-sm font-semibold transition-colors",
                   selectedStatus === tab.id
-                    ? "bg-gray-900 text-white dark:bg-slate-100 dark:text-slate-900"
-                    : "bg-gray-100 text-gray-600 hover:bg-gray-200 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700"
+                    ? "border-slate-900 bg-slate-900 text-white dark:border-slate-100 dark:bg-slate-100 dark:text-slate-900"
+                    : "border-slate-200 bg-white text-slate-600 hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-300 dark:hover:bg-slate-800",
                 )}
               >
                 {tab.name}
@@ -219,125 +210,156 @@ export default function AuctionsClient() {
 
         {/* 경매 목록 */}
         <div className="px-4 py-4">
-          {data ? (
+          {auctionsError ? (
+            <div className="rounded-lg border border-slate-200 bg-white px-4 py-8 text-center dark:border-slate-800 dark:bg-slate-900">
+              <p className="text-sm font-semibold text-slate-900 dark:text-slate-100">
+                경매 목록을 불러오지 못했습니다
+              </p>
+              <p className="mt-1 text-xs leading-relaxed text-slate-500 dark:text-slate-400">
+                잠시 후 다시 시도해주세요.
+              </p>
+              <button
+                type="button"
+                onClick={() => mutate()}
+                className="mt-4 inline-flex h-9 items-center rounded-lg bg-slate-900 px-3 text-xs font-semibold text-white transition-colors hover:bg-slate-800 dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-slate-200"
+              >
+                다시 불러오기
+              </button>
+            </div>
+          ) : data ? (
             <div className="grid grid-cols-2 gap-3">
-              {data.map((result) =>
-                result?.auctions?.map((auction) => (
-                  <Link
-                    key={auction.id}
-                    href={toAuctionPath(auction.id, auction.title)}
-                    className="block overflow-hidden rounded-xl border border-slate-100 bg-white dark:border-slate-800 dark:bg-slate-900"
-                  >
-                    {/* 이미지 */}
-                    <div className="relative aspect-[4/3]">
-                      {auction.photos?.[0] ? (
-                        <Image
-                          src={makeImageUrl(auction.photos[0], "public")}
-                          className="w-full h-full object-cover"
-                          alt={auction.title}
-                          fill
-                          sizes="(max-width: 640px) 50vw, 280px"
-                        />
-                      ) : (
-                        <div className="h-full w-full bg-gray-100 dark:bg-slate-800" />
-                      )}
-                      {/* 상태 뱃지 */}
-                      <div className="absolute top-2 left-2">
-                        <span
-                          className={cn(
-                            "inline-flex h-5 shrink-0 items-center whitespace-nowrap rounded-full px-2 text-[10px] font-semibold leading-none",
-                            auction.status === "진행중"
-                              ? "bg-emerald-500 text-white"
-                              : auction.status === "종료"
-                              ? "bg-slate-700 text-white"
-                              : "bg-amber-500 text-white"
-                          )}
-                        >
-                          {auction.status}
-                        </span>
-                      </div>
-                    </div>
-
-                    {/* 정보 */}
-                    <div className="p-2.5">
-                      <div className="flex items-center gap-1.5 mb-1">
-                        {auction.category && (
-                          <span className="inline-flex h-5 items-center rounded-md bg-primary/10 px-1.5 text-[10px] font-medium text-primary">
-                            {auction.category}
-                          </span>
+              {data.map(
+                (result) =>
+                  result?.auctions?.map((auction) => (
+                    <Link
+                      key={auction.id}
+                      href={toAuctionPath(auction.id, auction.title)}
+                      className="block overflow-hidden rounded-lg border border-slate-200 bg-white transition-colors hover:border-slate-300 dark:border-slate-800 dark:bg-slate-900 dark:hover:border-slate-700"
+                    >
+                      {/* 이미지 */}
+                      <div className="relative aspect-[4/3]">
+                        {auction.photos?.[0] ? (
+                          <Image
+                            src={makeImageUrl(auction.photos[0], "public")}
+                            className="w-full h-full object-cover"
+                            alt={auction.title}
+                            fill
+                            sizes="(max-width: 640px) 50vw, 280px"
+                          />
+                        ) : (
+                          <div className="h-full w-full bg-gray-100 dark:bg-slate-800" />
                         )}
-                        {auction.status === "진행중" && (
-                          <span className="line-clamp-1 text-[10px] font-medium text-emerald-600">
-                            {getTimeRemaining(auction.endAt)}
+                        {/* 상태 뱃지 */}
+                        <div className="absolute top-2 left-2">
+                          <span
+                            className={cn(
+                              "inline-flex h-5 shrink-0 items-center whitespace-nowrap rounded-md px-2 text-[10px] font-semibold leading-none",
+                              auction.status === "진행중"
+                                ? "bg-emerald-50 text-emerald-700 ring-1 ring-emerald-200"
+                                : auction.status === "종료"
+                                ? "bg-slate-100 text-slate-600 ring-1 ring-slate-200"
+                                : "bg-amber-50 text-amber-700 ring-1 ring-amber-200",
+                            )}
+                          >
+                            {auction.status}
                           </span>
-                        )}
-                      </div>
-                      <h3 className="line-clamp-1 text-sm font-semibold text-gray-900 dark:text-slate-100">
-                        {auction.title}
-                      </h3>
-                      <div className="mt-2 flex items-end justify-between gap-2">
-                        <div className="min-w-0">
-                          <p className="text-[10px] text-gray-400 dark:text-slate-500">현재가</p>
-                          <p className="text-sm font-bold text-primary line-clamp-1">
-                            {auction.currentPrice.toLocaleString()}원
-                          </p>
                         </div>
-                        <div className="text-right">
-                          <p className="text-[10px] text-gray-400 dark:text-slate-500">
-                            입찰 {auction._count.bids}회
-                          </p>
-                          <div className="mt-1 flex items-center justify-end gap-1">
-                            <div
-                              className={cn(
-                                hasBreederProgramFrame(auction.user?.breederPrograms)
-                                  ? "rounded-full p-0.5"
-                                  : "",
-                                hasBreederProgramFrame(auction.user?.breederPrograms)
-                                  ? getBreederProgramFrameClassName(
-                                      auction.user?.breederPrograms
-                                    )
-                                  : ""
-                              )}
-                            >
-                              {auction.user?.avatar ? (
-                                <Image
-                                  src={makeImageUrl(auction.user.avatar, "avatar")}
-                                  className={cn(
-                                    "h-4 w-4 rounded-full object-cover",
-                                    hasBreederProgramFrame(auction.user?.breederPrograms)
-                                      ? "ring-1 ring-white/70"
-                                      : ""
-                                  )}
-                                  width={16}
-                                  height={16}
-                                  alt=""
+                      </div>
+
+                      {/* 정보 */}
+                      <div className="p-3">
+                        <div className="flex items-center gap-1.5 mb-1">
+                          {auction.category && (
+                            <span className="inline-flex h-5 items-center rounded-md bg-slate-100 px-1.5 text-[10px] font-semibold text-slate-600 dark:bg-slate-800 dark:text-slate-300">
+                              {auction.category}
+                            </span>
+                          )}
+                          {auction.status === "진행중" && (
+                            <span className="line-clamp-1 text-[10px] font-semibold text-emerald-600">
+                              {getTimeRemaining(auction.endAt)}
+                            </span>
+                          )}
+                        </div>
+                        <h3 className="line-clamp-1 text-sm font-semibold text-gray-900 dark:text-slate-100">
+                          {auction.title}
+                        </h3>
+                        <div className="mt-2 flex items-end justify-between gap-2">
+                          <div className="min-w-0">
+                            <p className="text-[10px] text-gray-400 dark:text-slate-500">
+                              현재가
+                            </p>
+                            <p className="text-sm font-bold text-slate-950 line-clamp-1 dark:text-slate-50">
+                              {auction.currentPrice.toLocaleString()}원
+                            </p>
+                          </div>
+                          <div className="text-right">
+                            <p className="text-[10px] text-gray-400 dark:text-slate-500">
+                              입찰 {auction._count.bids}회
+                            </p>
+                            <div className="mt-1 flex items-center justify-end gap-1">
+                              <div
+                                className={cn(
+                                  hasBreederProgramFrame(
+                                    auction.user?.breederPrograms,
+                                  )
+                                    ? "rounded-full p-0.5"
+                                    : "",
+                                  hasBreederProgramFrame(
+                                    auction.user?.breederPrograms,
+                                  )
+                                    ? getBreederProgramFrameClassName(
+                                        auction.user?.breederPrograms,
+                                      )
+                                    : "",
+                                )}
+                              >
+                                {auction.user?.avatar ? (
+                                  <Image
+                                    src={makeImageUrl(
+                                      auction.user.avatar,
+                                      "avatar",
+                                    )}
+                                    className={cn(
+                                      "h-4 w-4 rounded-full object-cover",
+                                      hasBreederProgramFrame(
+                                        auction.user?.breederPrograms,
+                                      )
+                                        ? "ring-1 ring-white/70"
+                                        : "",
+                                    )}
+                                    width={16}
+                                    height={16}
+                                    alt=""
+                                  />
+                                ) : (
+                                  <div className="h-4 w-4 rounded-full bg-gray-200 dark:bg-slate-700" />
+                                )}
+                              </div>
+                              <div className="min-w-0 text-right">
+                                <span className="block max-w-[72px] truncate text-[10px] text-gray-500 dark:text-slate-400">
+                                  {auction.user?.name}
+                                </span>
+                                <BreederProgramBadgeList
+                                  programs={auction.user?.breederPrograms}
+                                  compact
+                                  className="mt-1 justify-end"
                                 />
-                              ) : (
-                                <div className="h-4 w-4 rounded-full bg-gray-200 dark:bg-slate-700" />
-                              )}
-                            </div>
-                            <div className="min-w-0 text-right">
-                              <span className="block max-w-[72px] truncate text-[10px] text-gray-500 dark:text-slate-400">
-                                {auction.user?.name}
-                              </span>
-                              <BreederProgramBadgeList
-                                programs={auction.user?.breederPrograms}
-                                compact
-                                className="mt-1 justify-end"
-                              />
+                              </div>
                             </div>
                           </div>
                         </div>
                       </div>
-                    </div>
-                  </Link>
-                ))
+                    </Link>
+                  )),
               )}
             </div>
           ) : (
             <div className="grid grid-cols-2 gap-3">
               {[...Array(4)].map((_, i) => (
-                <div key={i} className="animate-pulse overflow-hidden rounded-xl border border-slate-100 bg-white dark:border-slate-800 dark:bg-slate-900">
+                <div
+                  key={i}
+                  className="animate-pulse overflow-hidden rounded-lg border border-slate-200 bg-white dark:border-slate-800 dark:bg-slate-900"
+                >
                   <div className="aspect-[4/3] bg-gray-200 dark:bg-slate-800" />
                   <div className="space-y-2 p-2.5">
                     <div className="h-3 w-3/4 rounded bg-gray-200 dark:bg-slate-700" />
@@ -349,18 +371,33 @@ export default function AuctionsClient() {
           )}
 
           {/* 빈 상태 */}
-          {data && data.length > 0 && data[0].auctions.length === 0 && (
-            <div className="flex flex-col items-center justify-center py-20 text-gray-400 dark:text-slate-500">
-              <p className="text-lg font-medium">조건에 맞는 경매가 없습니다</p>
-              <p className="text-sm mt-1">첫 경매를 등록해 보세요!</p>
-            </div>
-          )}
+          {!auctionsError &&
+            data &&
+            data.length > 0 &&
+            data[0].auctions.length === 0 && (
+              <div className="flex flex-col items-center justify-center py-20 text-gray-400 dark:text-slate-500">
+                <p className="text-lg font-medium">
+                  조건에 맞는 경매가 없습니다
+                </p>
+                <p className="text-sm mt-1">첫 경매를 등록해 보세요!</p>
+              </div>
+            )}
         </div>
 
         {/* 경매 등록 버튼 */}
         <FloatingButton href="/auctions/create">
-          <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
+          <svg
+            className="w-6 h-6"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth="2"
+              d="M12 6v6m0 0v6m0-6h6m-6 0H6"
+            />
           </svg>
         </FloatingButton>
       </div>

--- a/app/(web)/auctions/[id]/AuctionDetailClient.tsx
+++ b/app/(web)/auctions/[id]/AuctionDetailClient.tsx
@@ -67,7 +67,9 @@ const AuctionDetailClient = () => {
   const router = useRouter();
   const pathname = usePathname();
   const { user } = useUser();
-  const auctionId = params?.id ? extractAuctionIdFromPath(params.id) : Number.NaN;
+  const auctionId = params?.id
+    ? extractAuctionIdFromPath(params.id)
+    : Number.NaN;
   const [bidAmount, setBidAmount] = useState<number | null>(null);
   const [countdown, setCountdown] = useState({ text: "", isEnded: false });
   const [imageIndex, setImageIndex] = useState(0);
@@ -84,16 +86,16 @@ const AuctionDetailClient = () => {
   // 경매 데이터 (5초 간격 새로고침)
   const { data, mutate: boundMutate } = useSWR<AuctionDetailResponse>(
     Number.isNaN(auctionId) ? null : `/api/auctions/${auctionId}`,
-    { refreshInterval: 5000 }
+    { refreshInterval: 5000 },
   );
 
   // 입찰 API
   const [submitBid, { loading: bidLoading }] = useMutation<BidResponse>(
-    Number.isNaN(auctionId) ? "" : `/api/auctions/${auctionId}/bid`
+    Number.isNaN(auctionId) ? "" : `/api/auctions/${auctionId}/bid`,
   );
   const [submitReport, { loading: reportLoading }] =
     useMutation<AuctionReportResponse>(
-      Number.isNaN(auctionId) ? "" : `/api/auctions/${auctionId}/report`
+      Number.isNaN(auctionId) ? "" : `/api/auctions/${auctionId}/report`,
     );
 
   // 1초마다 카운트다운 갱신
@@ -128,26 +130,28 @@ const AuctionDetailClient = () => {
   const auction = data?.auction;
   const extensionMinutes = Math.floor(AUCTION_EXTENSION_MS / (60 * 1000));
   const extensionWindowMinutes = Math.floor(
-    AUCTION_EXTENSION_WINDOW_MS / (60 * 1000)
+    AUCTION_EXTENSION_WINDOW_MS / (60 * 1000),
   );
   const winnerBid = auction?.winnerId
-    ? auction.bids.find((bid) => bid.userId === auction.winnerId) || auction.bids[0]
+    ? auction.bids.find((bid) => bid.userId === auction.winnerId) ||
+      auction.bids[0]
     : null;
   const isWinner = Boolean(auction?.winnerId && user?.id === auction.winnerId);
   const bidIncrement = auction ? getBidIncrement(auction.currentPrice) : 0;
   const minimumBid = auction ? auction.currentPrice + bidIncrement : 0;
   const isTopBidder = Boolean(
-    auction?.status === "진행중" && user?.id && auction?.bids?.[0]?.userId === user.id
+    auction?.status === "진행중" &&
+      user?.id &&
+      auction?.bids?.[0]?.userId === user.id,
   );
   const selectedBidAmount = bidAmount ?? minimumBid;
 
   const isToolRoute = pathname?.startsWith("/tool");
   const loginPath = isToolRoute ? "/tool/login" : "/auth/login";
   const hasBottomBidLayer = auction?.status === "진행중" && !data?.isOwner;
-  const mainImageSrc =
-    auction?.photos?.[imageIndex]
-      ? makeImageUrl(auction.photos[imageIndex], "public")
-      : DETAIL_FALLBACK_IMAGE;
+  const mainImageSrc = auction?.photos?.[imageIndex]
+    ? makeImageUrl(auction.photos[imageIndex], "public")
+    : DETAIL_FALLBACK_IMAGE;
   const auctionImageUrls =
     auction?.photos?.length && auction.photos.length > 0
       ? auction.photos.map((photo) => makeImageUrl(photo, "public"))
@@ -159,7 +163,6 @@ const AuctionDetailClient = () => {
       return Math.min(prev, auctionImageUrls.length - 1);
     });
   }, [auctionImageUrls.length]);
-
 
   const handleImageTouchStart = (event: React.TouchEvent) => {
     isImageDragging.current = false;
@@ -191,7 +194,10 @@ const AuctionDetailClient = () => {
       return;
     }
     if (distance < -50) {
-      setImageIndex((prev) => (prev - 1 + auctionImageUrls.length) % auctionImageUrls.length);
+      setImageIndex(
+        (prev) =>
+          (prev - 1 + auctionImageUrls.length) % auctionImageUrls.length,
+      );
       return;
     }
 
@@ -205,7 +211,8 @@ const AuctionDetailClient = () => {
     const increment = getBidIncrement(basePrice);
     const minAmount = basePrice + increment;
 
-    if (!Number.isFinite(targetAmount) || targetAmount <= minAmount) return minAmount;
+    if (!Number.isFinite(targetAmount) || targetAmount <= minAmount)
+      return minAmount;
 
     const steps = Math.ceil((targetAmount - basePrice) / increment);
     return basePrice + steps * increment;
@@ -256,7 +263,10 @@ const AuctionDetailClient = () => {
       requires_login: !user,
     });
 
-    if (!user) return router.push(`${loginPath}?next=${encodeURIComponent(pathname || "/")}`);
+    if (!user)
+      return router.push(
+        `${loginPath}?next=${encodeURIComponent(pathname || "/")}`,
+      );
     if (bidLoading) return;
     if (isTopBidder) {
       toast.error("현재 최고 입찰자는 다시 입찰할 수 없습니다.");
@@ -269,12 +279,14 @@ const AuctionDetailClient = () => {
 
     const amount = selectedBidAmount;
     if (!Number.isInteger(amount) || amount < minimumBid) {
-      toast.error(`최소 ${minimumBid.toLocaleString()}원 이상 입찰해야 합니다.`);
+      toast.error(
+        `최소 ${minimumBid.toLocaleString()}원 이상 입찰해야 합니다.`,
+      );
       return;
     }
 
     const confirmed = window.confirm(
-      `정말 ${amount.toLocaleString()}원으로 입찰하시겠습니까?\n입찰 취소가 불가능합니다.`
+      `정말 ${amount.toLocaleString()}원으로 입찰하시겠습니까?\n입찰 취소가 불가능합니다.`,
     );
     if (!confirmed) {
       return;
@@ -293,7 +305,9 @@ const AuctionDetailClient = () => {
           });
           toast.success("입찰이 완료되었습니다!");
           if (result.extended) {
-            toast.info(`마감 임박 입찰로 경매 시간이 ${extensionMinutes}분 연장되었습니다.`);
+            toast.info(
+              `마감 임박 입찰로 경매 시간이 ${extensionMinutes}분 연장되었습니다.`,
+            );
           }
           setBidAmount(null);
           boundMutate();
@@ -305,7 +319,12 @@ const AuctionDetailClient = () => {
             error_code: result.errorCode || null,
             error_message: result.error || "입찰에 실패했습니다.",
           });
-          toast.error(getAuctionErrorMessage(result.errorCode, result.error || "입찰에 실패했습니다."));
+          toast.error(
+            getAuctionErrorMessage(
+              result.errorCode,
+              result.error || "입찰에 실패했습니다.",
+            ),
+          );
         }
       },
       onError() {
@@ -323,7 +342,10 @@ const AuctionDetailClient = () => {
 
   const getAuctionUrl = () => {
     if (!auction || typeof window === "undefined") return "";
-    return new URL(toAuctionPath(auction.id, auction.title), window.location.origin).toString();
+    return new URL(
+      toAuctionPath(auction.id, auction.title),
+      window.location.origin,
+    ).toString();
   };
 
   const copyToClipboard = async (value: string) => {
@@ -394,7 +416,9 @@ const AuctionDetailClient = () => {
         channel: "clipboard_fallback",
         share_url: url,
       });
-      toast.info("이 기기에서는 바로 공유를 지원하지 않아 링크를 복사했습니다.");
+      toast.info(
+        "이 기기에서는 바로 공유를 지원하지 않아 링크를 복사했습니다.",
+      );
     } catch (error) {
       if (error instanceof Error && error.name === "AbortError") return;
       toast.error("공유에 실패했습니다.");
@@ -425,7 +449,12 @@ const AuctionDetailClient = () => {
             error_code: result.errorCode || null,
             error_message: result.error || "신고 접수에 실패했습니다.",
           });
-          toast.error(getAuctionErrorMessage(result.errorCode, result.error || "신고 접수에 실패했습니다."));
+          toast.error(
+            getAuctionErrorMessage(
+              result.errorCode,
+              result.error || "신고 접수에 실패했습니다.",
+            ),
+          );
           return;
         }
         trackEvent(ANALYTICS_EVENTS.auctionReportSubmitted, {
@@ -465,7 +494,7 @@ const AuctionDetailClient = () => {
       <div
         className={cn(
           "pb-24",
-          hasBottomBidLayer && "pb-[calc(20rem+env(safe-area-inset-bottom))]"
+          hasBottomBidLayer && "pb-[calc(20rem+env(safe-area-inset-bottom))]",
         )}
       >
         {/* 이미지 슬라이더 */}
@@ -498,13 +527,27 @@ const AuctionDetailClient = () => {
                 type="button"
                 onClick={(event) => {
                   event.stopPropagation();
-                  setImageIndex((prev) => (prev - 1 + auction.photos.length) % auction.photos.length);
+                  setImageIndex(
+                    (prev) =>
+                      (prev - 1 + auction.photos.length) %
+                      auction.photos.length,
+                  );
                 }}
                 className="absolute left-2 top-1/2 -translate-y-1/2 rounded-full bg-black/40 p-2 text-white transition-all hover:bg-black/55 md:opacity-0 md:group-hover:opacity-100"
                 aria-label="이전 이미지"
               >
-                <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+                <svg
+                  className="h-5 w-5"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M15 19l-7-7 7-7"
+                  />
                 </svg>
               </button>
               <button
@@ -516,8 +559,18 @@ const AuctionDetailClient = () => {
                 className="absolute right-2 top-1/2 -translate-y-1/2 rounded-full bg-black/40 p-2 text-white transition-all hover:bg-black/55 md:opacity-0 md:group-hover:opacity-100"
                 aria-label="다음 이미지"
               >
-                <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                <svg
+                  className="h-5 w-5"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M9 5l7 7-7 7"
+                  />
                 </svg>
               </button>
 
@@ -531,7 +584,9 @@ const AuctionDetailClient = () => {
                     }}
                     className={cn(
                       "h-2 w-2 rounded-full transition-all",
-                      imageIndex === i ? "bg-white dark:bg-white" : "bg-white/50 dark:bg-white/50"
+                      imageIndex === i
+                        ? "bg-white dark:bg-white"
+                        : "bg-white/50 dark:bg-white/50",
                     )}
                     aria-label={`${i + 1}번 이미지로 이동`}
                   />
@@ -542,27 +597,29 @@ const AuctionDetailClient = () => {
         </div>
 
         <ImageLightbox
-        images={auctionImageUrls}
-        isOpen={isImageLightboxOpen}
-        currentIndex={imageIndex}
-        onClose={() => setIsImageLightboxOpen(false)}
-        onIndexChange={setImageIndex}
-        altPrefix="경매 이미지"
+          images={auctionImageUrls}
+          isOpen={isImageLightboxOpen}
+          currentIndex={imageIndex}
+          onClose={() => setIsImageLightboxOpen(false)}
+          onIndexChange={setImageIndex}
+          altPrefix="경매 이미지"
         />
 
         <div className="px-4">
           {/* 카운트다운 배너 */}
           <div
             className={cn(
-              "mt-4 py-3 px-4 rounded-xl text-center font-bold",
+              "mt-4 rounded-lg border px-4 py-3 text-center font-bold",
               countdown.isEnded || auction.status !== "진행중"
-                ? "bg-gray-100 text-gray-500 dark:bg-slate-800 dark:text-slate-300"
-                : "bg-red-50 text-red-600 dark:bg-rose-950/40 dark:text-rose-300"
+                ? "border-slate-200 bg-white text-slate-500 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-300"
+                : "border-rose-200 bg-white text-rose-600 dark:border-rose-800 dark:bg-slate-900 dark:text-rose-300",
             )}
           >
             {auction.status === "진행중" ? (
               <div>
-                <span className="text-xs font-medium block mb-0.5">남은 시간</span>
+                <span className="text-xs font-medium block mb-0.5">
+                  남은 시간
+                </span>
                 <span className="text-lg">{countdown.text}</span>
               </div>
             ) : (
@@ -570,17 +627,20 @@ const AuctionDetailClient = () => {
                 {auction.status === "종료"
                   ? "경매가 종료되었습니다"
                   : auction.status === "취소"
-                    ? "운영 처리로 경매가 중단(취소)되었습니다"
-                    : "유찰되었습니다"}
+                  ? "운영 처리로 경매가 중단(취소)되었습니다"
+                  : "유찰되었습니다"}
               </span>
             )}
           </div>
 
           {auction.status === "취소" && (
-            <div className="mt-3 rounded-xl border border-rose-200 bg-rose-50 px-3.5 py-3 dark:border-rose-800 dark:bg-rose-950/40">
-              <p className="text-sm font-bold text-rose-800 dark:text-rose-200">신고/운영 처리로 경매 중단</p>
+            <div className="mt-3 rounded-lg border border-rose-200 bg-rose-50 px-3.5 py-3 dark:border-rose-800 dark:bg-rose-950/40">
+              <p className="text-sm font-bold text-rose-800 dark:text-rose-200">
+                신고/운영 처리로 경매 중단
+              </p>
               <p className="mt-1 text-xs leading-relaxed text-rose-900 dark:text-rose-200/90">
-                이 경매는 운영 정책에 따라 취소되었습니다. 추가 이의가 있으면 신고 접수 채널로 문의해 주세요.
+                이 경매는 운영 정책에 따라 취소되었습니다. 추가 이의가 있으면
+                신고 접수 채널로 문의해 주세요.
               </p>
             </div>
           )}
@@ -588,16 +648,18 @@ const AuctionDetailClient = () => {
           {auction.status === "종료" && winnerBid && (
             <div
               className={cn(
-                "mt-3 rounded-xl border px-3.5 py-3",
+                "mt-3 rounded-lg border px-3.5 py-3",
                 isWinner
                   ? "border-emerald-200 bg-emerald-50 dark:border-emerald-800 dark:bg-emerald-950/35"
-                  : "border-blue-200 bg-blue-50 dark:border-blue-800 dark:bg-blue-950/35"
+                  : "border-blue-200 bg-blue-50 dark:border-blue-800 dark:bg-blue-950/35",
               )}
             >
               <p
                 className={cn(
                   "text-sm font-bold",
-                  isWinner ? "text-emerald-800 dark:text-emerald-200" : "text-blue-800 dark:text-blue-200"
+                  isWinner
+                    ? "text-emerald-800 dark:text-emerald-200"
+                    : "text-blue-800 dark:text-blue-200",
                 )}
               >
                 {isWinner ? "낙찰 완료: 축하합니다!" : "낙찰 결과"}
@@ -607,18 +669,21 @@ const AuctionDetailClient = () => {
                 <p>낙찰가: {winnerBid.amount.toLocaleString()}원</p>
                 <p>종료시각: {new Date(auction.endAt).toLocaleString()}</p>
               </div>
-              <div className="mt-2 rounded-lg border border-white/80 bg-white/80 px-2.5 py-2 text-[11px] text-slate-700 dark:border-slate-700 dark:bg-slate-800/80 dark:text-slate-200">
+              <div className="mt-2 rounded-md border border-white/80 bg-white/80 px-2.5 py-2 text-[11px] text-slate-700 dark:border-slate-700 dark:bg-slate-800/80 dark:text-slate-200">
                 {isWinner ? (
                   <p>
-                    판매자 신뢰 정보(전화/이메일/블로그)를 확인해 거래를 진행하세요. 분쟁 발생 시 신고 기능을 사용하세요.
+                    판매자 신뢰 정보(전화/이메일/블로그)를 확인해 거래를
+                    진행하세요. 분쟁 발생 시 신고 기능을 사용하세요.
                   </p>
                 ) : data?.isOwner ? (
                   <p>
-                    낙찰자와 거래를 진행하세요. 거래 조건 분쟁이 있으면 신고 접수로 운영 검토를 요청할 수 있습니다.
+                    낙찰자와 거래를 진행하세요. 거래 조건 분쟁이 있으면 신고
+                    접수로 운영 검토를 요청할 수 있습니다.
                   </p>
                 ) : (
                   <p>
-                    경매가 낙찰로 종료되었습니다. 참여 내역은 알림에서 확인할 수 있습니다.
+                    경매가 낙찰로 종료되었습니다. 참여 내역은 알림에서 확인할 수
+                    있습니다.
                   </p>
                 )}
               </div>
@@ -634,8 +699,10 @@ const AuctionDetailClient = () => {
                     ? "rounded-[18px] p-1"
                     : "",
                   hasBreederProgramFrame(auction.user?.breederPrograms)
-                    ? getBreederProgramFrameClassName(auction.user?.breederPrograms)
-                    : ""
+                    ? getBreederProgramFrameClassName(
+                        auction.user?.breederPrograms,
+                      )
+                    : "",
                 )}
               >
                 {auction.user?.avatar ? (
@@ -645,7 +712,7 @@ const AuctionDetailClient = () => {
                       "h-10 w-10 rounded-full object-cover",
                       hasBreederProgramFrame(auction.user?.breederPrograms)
                         ? "ring-2 ring-white/70"
-                        : ""
+                        : "",
                     )}
                     width={40}
                     height={40}
@@ -656,8 +723,12 @@ const AuctionDetailClient = () => {
                 )}
               </div>
               <div>
-                <p className="text-sm font-semibold text-gray-900 dark:text-slate-100">{auction.user?.name}</p>
-                <p className="text-xs text-gray-400 dark:text-slate-500">경매 등록자</p>
+                <p className="text-sm font-semibold text-gray-900 dark:text-slate-100">
+                  {auction.user?.name}
+                </p>
+                <p className="text-xs text-gray-400 dark:text-slate-500">
+                  경매 등록자
+                </p>
                 <BreederProgramBadgeList
                   programs={auction.user?.breederPrograms}
                   compact
@@ -676,8 +747,10 @@ const AuctionDetailClient = () => {
                     ? "rounded-[18px] p-1"
                     : "",
                   hasBreederProgramFrame(auction.user?.breederPrograms)
-                    ? getBreederProgramFrameClassName(auction.user?.breederPrograms)
-                    : ""
+                    ? getBreederProgramFrameClassName(
+                        auction.user?.breederPrograms,
+                      )
+                    : "",
                 )}
               >
                 {auction.user?.avatar ? (
@@ -687,7 +760,7 @@ const AuctionDetailClient = () => {
                       "h-10 w-10 rounded-full object-cover",
                       hasBreederProgramFrame(auction.user?.breederPrograms)
                         ? "ring-2 ring-white/70"
-                        : ""
+                        : "",
                     )}
                     width={40}
                     height={40}
@@ -698,8 +771,12 @@ const AuctionDetailClient = () => {
                 )}
               </div>
               <div>
-                <p className="text-sm font-semibold text-gray-900 dark:text-slate-100">{auction.user?.name}</p>
-                <p className="text-xs text-gray-400 dark:text-slate-500">경매 등록자</p>
+                <p className="text-sm font-semibold text-gray-900 dark:text-slate-100">
+                  {auction.user?.name}
+                </p>
+                <p className="text-xs text-gray-400 dark:text-slate-500">
+                  경매 등록자
+                </p>
                 <BreederProgramBadgeList
                   programs={auction.user?.breederPrograms}
                   compact
@@ -713,16 +790,16 @@ const AuctionDetailClient = () => {
           <div className="space-y-3 border-b border-gray-100 py-4 dark:border-slate-800">
             <div className="flex items-center gap-2">
               {auction.category && (
-                <span className="text-xs font-medium text-primary bg-primary/10 px-2 py-0.5 rounded">
+                <span className="rounded-md bg-slate-100 px-2 py-0.5 text-xs font-semibold text-slate-600 dark:bg-slate-800 dark:text-slate-300">
                   {auction.category}
                 </span>
               )}
               <span
                 className={cn(
-                  "text-xs px-2 py-0.5 rounded-full font-medium",
+                  "rounded-md px-2 py-0.5 text-xs font-semibold",
                   auction.status === "진행중"
-                    ? "bg-green-100 text-green-700"
-                    : "bg-gray-200 text-gray-500 dark:bg-slate-700 dark:text-slate-300"
+                    ? "bg-emerald-50 text-emerald-700 ring-1 ring-emerald-200"
+                    : "bg-gray-200 text-gray-500 dark:bg-slate-700 dark:text-slate-300",
                 )}
               >
                 {auction.status}
@@ -738,7 +815,7 @@ const AuctionDetailClient = () => {
               {data?.isOwner && data?.canEdit && !isToolRoute ? (
                 <Link
                   href={`${toAuctionPath(auction.id, auction.title)}/edit`}
-                  className="inline-flex h-10 items-center rounded-xl bg-emerald-600 px-4 text-sm font-semibold text-white transition-colors hover:bg-emerald-700"
+                  className="inline-flex h-10 items-center rounded-lg border border-slate-200 bg-white px-4 text-sm font-semibold text-slate-700 transition-colors hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200 dark:hover:bg-slate-800"
                 >
                   경매 수정하기
                 </Link>
@@ -746,21 +823,22 @@ const AuctionDetailClient = () => {
               <button
                 type="button"
                 onClick={handleCopyAuctionLink}
-                className="inline-flex h-10 items-center rounded-xl bg-amber-500 px-4 text-sm font-semibold text-white transition-colors hover:bg-amber-600"
+                className="inline-flex h-10 items-center rounded-lg bg-slate-900 px-4 text-sm font-semibold text-white transition-colors hover:bg-slate-800 dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-slate-200"
               >
                 링크 복사
               </button>
               <button
                 type="button"
                 onClick={handleShareAuction}
-                className="inline-flex h-10 items-center rounded-xl bg-sky-600 px-4 text-sm font-semibold text-white transition-colors hover:bg-sky-700"
+                className="inline-flex h-10 items-center rounded-lg border border-slate-200 bg-white px-4 text-sm font-semibold text-slate-700 transition-colors hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200 dark:hover:bg-slate-800"
               >
                 공유하기
               </button>
             </div>
             {data?.isOwner && !data?.canEdit ? (
               <p className="text-xs text-slate-500 dark:text-slate-400">
-                진행중 상태에서 등록 후 10분 이내, 입찰이 없을 때만 수정할 수 있습니다.
+                진행중 상태에서 등록 후 10분 이내, 입찰이 없을 때만 수정할 수
+                있습니다.
               </p>
             ) : null}
             {(auction.sellerPhone ||
@@ -771,10 +849,16 @@ const AuctionDetailClient = () => {
               auction.sellerTrustNote ||
               auction.sellerProofImage) && (
               <div className="rounded-lg border border-slate-200 bg-slate-50 px-3.5 py-3 dark:border-slate-700 dark:bg-slate-800/70">
-                <p className="text-xs font-semibold text-slate-700 dark:text-slate-200">판매자 신뢰 정보</p>
+                <p className="text-xs font-semibold text-slate-700 dark:text-slate-200">
+                  판매자 신뢰 정보
+                </p>
                 <div className="mt-2 space-y-1 text-xs text-slate-600 dark:text-slate-300">
-                  {auction.sellerPhone ? <p>연락처: {auction.sellerPhone}</p> : null}
-                  {auction.sellerEmail ? <p>이메일: {auction.sellerEmail}</p> : null}
+                  {auction.sellerPhone ? (
+                    <p>연락처: {auction.sellerPhone}</p>
+                  ) : null}
+                  {auction.sellerEmail ? (
+                    <p>이메일: {auction.sellerEmail}</p>
+                  ) : null}
                   {auction.sellerBlogUrl ? (
                     <a
                       href={auction.sellerBlogUrl}
@@ -785,8 +869,12 @@ const AuctionDetailClient = () => {
                       블로그/프로필 링크 확인
                     </a>
                   ) : null}
-                  {auction.sellerCafeNick ? <p>카페 닉네임: {auction.sellerCafeNick}</p> : null}
-                  {auction.sellerBandNick ? <p>밴드 닉네임: {auction.sellerBandNick}</p> : null}
+                  {auction.sellerCafeNick ? (
+                    <p>카페 닉네임: {auction.sellerCafeNick}</p>
+                  ) : null}
+                  {auction.sellerBandNick ? (
+                    <p>밴드 닉네임: {auction.sellerBandNick}</p>
+                  ) : null}
                   {auction.sellerTrustNote ? (
                     <p className="whitespace-pre-line break-words [overflow-wrap:anywhere]">
                       추가 안내: {auction.sellerTrustNote}
@@ -811,20 +899,28 @@ const AuctionDetailClient = () => {
           <div className="py-4 space-y-4">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-xs text-gray-400 dark:text-slate-500">시작가</p>
-                <p className="text-sm text-gray-500 dark:text-slate-300">{auction.startPrice.toLocaleString()}원</p>
+                <p className="text-xs text-gray-400 dark:text-slate-500">
+                  시작가
+                </p>
+                <p className="text-sm text-gray-500 dark:text-slate-300">
+                  {auction.startPrice.toLocaleString()}원
+                </p>
               </div>
               <div className="text-right">
-                <p className="text-xs text-gray-400 dark:text-slate-500">현재 최고가</p>
+                <p className="text-xs text-gray-400 dark:text-slate-500">
+                  현재 최고가
+                </p>
                 <p className="text-2xl font-bold text-primary">
                   {auction.currentPrice.toLocaleString()}원
                 </p>
               </div>
             </div>
 
-            <div className="rounded-xl border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-800/70 px-3.5 py-3">
+            <div className="rounded-lg border border-slate-200 bg-white px-3.5 py-3 dark:border-slate-700 dark:bg-slate-900">
               <div className="flex items-center justify-between gap-3">
-                <p className="text-sm font-semibold text-slate-800 dark:text-slate-100">경매 규칙</p>
+                <p className="text-sm font-semibold text-slate-800 dark:text-slate-100">
+                  경매 규칙
+                </p>
                 {!isToolRoute ? (
                   <Link
                     href="/auctions/rules"
@@ -835,16 +931,23 @@ const AuctionDetailClient = () => {
                 ) : null}
               </div>
               <ul className="mt-2 space-y-1 text-xs text-slate-600 dark:text-slate-300">
-                <li>• 현재가 기준 입찰 단위: {getBidIncrement(auction.currentPrice).toLocaleString()}원</li>
-                <li>• 마감 {extensionWindowMinutes}분 이내 입찰 시 종료 시간이 {extensionMinutes}분 연장됩니다.</li>
+                <li>
+                  • 현재가 기준 입찰 단위:{" "}
+                  {getBidIncrement(auction.currentPrice).toLocaleString()}원
+                </li>
+                <li>
+                  • 마감 {extensionWindowMinutes}분 이내 입찰 시 종료 시간이{" "}
+                  {extensionMinutes}분 연장됩니다.
+                </li>
                 <li>• 입찰은 취소할 수 없으며, 본인 경매 입찰은 불가합니다.</li>
                 <li>• 현재 최고 입찰자는 재입찰할 수 없습니다.</li>
               </ul>
               <div className="mt-3 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2.5 text-xs text-amber-900 dark:border-amber-700 dark:bg-amber-950/40 dark:text-amber-200">
                 <p className="font-semibold">분쟁/신고 안내</p>
                 <p className="mt-1 leading-relaxed">
-                  본 서비스는 거래 당사자 간 분쟁에 대해 법적 책임을 지지 않습니다.
-                  다만 문제가 발생하면 신고를 접수하여 운영정책에 따라 검토 및 제재를 진행합니다.
+                  본 서비스는 거래 당사자 간 분쟁에 대해 법적 책임을 지지
+                  않습니다. 다만 문제가 발생하면 신고를 접수하여 운영정책에 따라
+                  검토 및 제재를 진행합니다.
                 </p>
                 <p className="mt-1 leading-relaxed font-semibold">
                   카카오 로그인 기반 계정은 위반 시 영구 참여 제한됩니다.
@@ -859,12 +962,17 @@ const AuctionDetailClient = () => {
                 ) : null}
                 {!data?.isOwner && (
                   <div className="mt-3 rounded-lg border border-amber-300 bg-white/70 p-2.5 dark:border-amber-700 dark:bg-slate-900/65">
-                    <p className="text-[11px] font-semibold text-amber-900 dark:text-amber-200">빠른 신고 접수</p>
+                    <p className="text-[11px] font-semibold text-amber-900 dark:text-amber-200">
+                      빠른 신고 접수
+                    </p>
                     <div className="mt-1.5 space-y-1.5">
                       <select
                         value={reportReason}
                         onChange={(event) =>
-                          setReportReason(event.target.value as (typeof REPORT_REASONS)[number])
+                          setReportReason(
+                            event.target
+                              .value as (typeof REPORT_REASONS)[number],
+                          )
                         }
                         className="w-full rounded-md border border-amber-200 bg-white px-2 py-1.5 text-[11px] dark:border-amber-700 dark:bg-slate-900 dark:text-slate-100"
                       >
@@ -876,7 +984,9 @@ const AuctionDetailClient = () => {
                       </select>
                       <textarea
                         value={reportDetail}
-                        onChange={(event) => setReportDetail(event.target.value)}
+                        onChange={(event) =>
+                          setReportDetail(event.target.value)
+                        }
                         placeholder="신고 내용을 5자 이상 입력해주세요."
                         rows={2}
                         className="w-full rounded-md border border-amber-200 bg-white px-2 py-1.5 text-[11px] dark:border-amber-700 dark:bg-slate-900 dark:text-slate-100 dark:placeholder:text-slate-500"
@@ -909,13 +1019,14 @@ const AuctionDetailClient = () => {
                         "flex items-center justify-between py-2 px-3 rounded-lg",
                         i === 0
                           ? "border border-primary/20 bg-primary/5 dark:border-primary/30 dark:bg-primary/10"
-                          : "bg-gray-50 dark:bg-slate-800/70"
+                          : "bg-gray-50 dark:bg-slate-800/70",
                       )}
                     >
                       <div className="flex items-center gap-2">
                         {i === 0 && (
                           <span className="text-xs font-bold text-primary">
-                            {auction.status === "종료" && auction.winnerId === bid.userId
+                            {auction.status === "종료" &&
+                            auction.winnerId === bid.userId
                               ? "낙찰"
                               : "1위"}
                           </span>
@@ -931,7 +1042,9 @@ const AuctionDetailClient = () => {
                         ) : (
                           <div className="h-6 w-6 rounded-full bg-gray-200 dark:bg-slate-700" />
                         )}
-                        <span className="text-sm text-gray-700 dark:text-slate-200">{bid.user?.name}</span>
+                        <span className="text-sm text-gray-700 dark:text-slate-200">
+                          {bid.user?.name}
+                        </span>
                       </div>
                       <div className="text-right">
                         <p className="text-sm font-semibold text-gray-900 dark:text-slate-100">
@@ -958,7 +1071,7 @@ const AuctionDetailClient = () => {
       {hasBottomBidLayer && (
         <div className="fixed bottom-0 left-0 right-0 bg-white dark:bg-slate-900 border-t border-gray-200 dark:border-slate-700 z-10">
           <div className="max-w-xl mx-auto px-4 py-3">
-            <div className="mb-2.5 rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-800/70 px-3 py-2">
+            <div className="mb-2.5 rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 dark:border-slate-700 dark:bg-slate-800/70">
               <label className="flex items-start gap-2 text-[11px] text-slate-700 dark:text-slate-300 leading-relaxed">
                 <input
                   type="checkbox"
@@ -966,13 +1079,17 @@ const AuctionDetailClient = () => {
                   onChange={(event) => setAgreedBidRule(event.target.checked)}
                   className="mt-0.5"
                 />
-                <span>입찰 취소 불가, 마감 임박 자동연장 규칙을 확인했습니다.</span>
+                <span>
+                  입찰 취소 불가, 마감 임박 자동연장 규칙을 확인했습니다.
+                </span>
               </label>
               <label className="mt-1 flex items-start gap-2 text-[11px] text-slate-700 dark:text-slate-300 leading-relaxed">
                 <input
                   type="checkbox"
                   checked={agreedDisputePolicy}
-                  onChange={(event) => setAgreedDisputePolicy(event.target.checked)}
+                  onChange={(event) =>
+                    setAgreedDisputePolicy(event.target.checked)
+                  }
                   className="mt-0.5"
                 />
                 <span>분쟁 책임 제한 및 신고 접수 정책을 확인했습니다.</span>
@@ -983,49 +1100,51 @@ const AuctionDetailClient = () => {
                 <button
                   onClick={() => increaseBidAmount(bidIncrement)}
                   disabled={isTopBidder}
-                  className="rounded-lg bg-gray-100 px-2 py-2 text-[11px] font-semibold text-gray-700 transition-colors hover:bg-gray-200 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-slate-700 dark:text-slate-100 dark:hover:bg-slate-600"
+                  className="rounded-md border border-slate-200 bg-white px-2 py-2 text-[11px] font-semibold text-gray-700 transition-colors hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100 dark:hover:bg-slate-700"
                 >
                   +1틱
                 </button>
                 <button
                   onClick={() => increaseBidAmount(bidIncrement * 2)}
                   disabled={isTopBidder}
-                  className="rounded-lg bg-gray-100 px-2 py-2 text-[11px] font-semibold text-gray-700 transition-colors hover:bg-gray-200 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-slate-700 dark:text-slate-100 dark:hover:bg-slate-600"
+                  className="rounded-md border border-slate-200 bg-white px-2 py-2 text-[11px] font-semibold text-gray-700 transition-colors hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100 dark:hover:bg-slate-700"
                 >
                   +2틱
                 </button>
                 <button
                   onClick={() => increaseBidAmount(10_000)}
                   disabled={isTopBidder}
-                  className="rounded-lg bg-gray-100 px-2 py-2 text-[11px] font-semibold text-gray-700 transition-colors hover:bg-gray-200 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-slate-700 dark:text-slate-100 dark:hover:bg-slate-600"
+                  className="rounded-md border border-slate-200 bg-white px-2 py-2 text-[11px] font-semibold text-gray-700 transition-colors hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100 dark:hover:bg-slate-700"
                 >
                   +10,000원
                 </button>
                 <button
                   onClick={() => increaseBidAmount(50_000)}
                   disabled={isTopBidder}
-                  className="rounded-lg bg-gray-100 px-2 py-2 text-[11px] font-semibold text-gray-700 transition-colors hover:bg-gray-200 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-slate-700 dark:text-slate-100 dark:hover:bg-slate-600"
+                  className="rounded-md border border-slate-200 bg-white px-2 py-2 text-[11px] font-semibold text-gray-700 transition-colors hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100 dark:hover:bg-slate-700"
                 >
                   +50,000원
                 </button>
                 <button
                   onClick={() => increaseBidAmount(100_000)}
                   disabled={isTopBidder}
-                  className="rounded-lg bg-gray-100 px-2 py-2 text-[11px] font-semibold text-gray-700 transition-colors hover:bg-gray-200 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-slate-700 dark:text-slate-100 dark:hover:bg-slate-600"
+                  className="rounded-md border border-slate-200 bg-white px-2 py-2 text-[11px] font-semibold text-gray-700 transition-colors hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100 dark:hover:bg-slate-700"
                 >
                   +100,000원
                 </button>
                 <button
                   onClick={() => setBidAmount(minimumBid)}
                   disabled={isTopBidder}
-                  className="rounded-lg bg-gray-100 px-2 py-2 text-[11px] font-semibold text-gray-700 transition-colors hover:bg-gray-200 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-slate-700 dark:text-slate-100 dark:hover:bg-slate-600"
+                  className="rounded-md border border-slate-200 bg-white px-2 py-2 text-[11px] font-semibold text-gray-700 transition-colors hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100 dark:hover:bg-slate-700"
                 >
                   최소가
                 </button>
               </div>
               <div className="flex items-center gap-2">
-                <div className="flex-1 rounded-lg bg-gray-100 px-3 py-2 text-right dark:bg-slate-800">
-                  <p className="text-[10px] font-medium text-gray-500 dark:text-slate-400">선택 입찰가</p>
+                <div className="flex-1 rounded-lg border border-slate-200 bg-white px-3 py-2 text-right dark:border-slate-700 dark:bg-slate-800">
+                  <p className="text-[10px] font-medium text-gray-500 dark:text-slate-400">
+                    선택 입찰가
+                  </p>
                   <p className="text-sm font-bold text-gray-900 dark:text-slate-100">
                     {selectedBidAmount.toLocaleString()}원
                   </p>
@@ -1033,9 +1152,12 @@ const AuctionDetailClient = () => {
                 <button
                   onClick={handleBid}
                   disabled={
-                    bidLoading || !agreedBidRule || !agreedDisputePolicy || isTopBidder
+                    bidLoading ||
+                    !agreedBidRule ||
+                    !agreedDisputePolicy ||
+                    isTopBidder
                   }
-                  className="flex-shrink-0 px-5 py-2.5 bg-primary text-white rounded-lg font-medium text-sm hover:bg-primary/90 transition-colors disabled:opacity-50"
+                  className="flex-shrink-0 rounded-lg bg-primary px-5 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-primary/90 disabled:opacity-50"
                 >
                   {bidLoading ? "..." : "입찰"}
                 </button>
@@ -1043,7 +1165,8 @@ const AuctionDetailClient = () => {
             </div>
             {isTopBidder ? (
               <p className="mt-2 text-[11px] text-amber-700 dark:text-amber-300">
-                현재 최고 입찰자는 다시 입찰할 수 없습니다. 다른 참여자의 입찰을 기다려주세요.
+                현재 최고 입찰자는 다시 입찰할 수 없습니다. 다른 참여자의 입찰을
+                기다려주세요.
               </p>
             ) : null}
           </div>

--- a/app/(web)/auctions/create/CreateAuctionClient.tsx
+++ b/app/(web)/auctions/create/CreateAuctionClient.tsx
@@ -138,37 +138,51 @@ const CreateAuctionClient = () => {
   const [shareModalOpen, setShareModalOpen] = useState(false);
   const [createdAuctionId, setCreatedAuctionId] = useState<number | null>(null);
   const [createdAuctionTitle, setCreatedAuctionTitle] = useState<string>("");
-  const [lastCreatedSignature, setLastCreatedSignature] = useState<string | null>(null);
+  const [lastCreatedSignature, setLastCreatedSignature] = useState<
+    string | null
+  >(null);
   const [confirmModalOpen, setConfirmModalOpen] = useState(false);
   const [pendingSubmission, setPendingSubmission] =
     useState<PendingCreateSubmission | null>(null);
-  const [customFieldErrors, setCustomFieldErrors] = useState<CustomFieldErrors>({});
-  const [selectedBloodlineRootId, setSelectedBloodlineRootId] = useState<string>("");
+  const [customFieldErrors, setCustomFieldErrors] = useState<CustomFieldErrors>(
+    {},
+  );
+  const [selectedBloodlineRootId, setSelectedBloodlineRootId] =
+    useState<string>("");
 
   const photosSectionRef = useRef<HTMLDivElement | null>(null);
   const categorySectionRef = useRef<HTMLDivElement | null>(null);
   const agreementSectionRef = useRef<HTMLDivElement | null>(null);
   const durationSectionRef = useRef<HTMLDivElement | null>(null);
 
-  const { register, handleSubmit, setValue, watch, formState: { errors } } = useForm<AuctionForm>();
+  const {
+    register,
+    handleSubmit,
+    setValue,
+    watch,
+    formState: { errors },
+  } = useForm<AuctionForm>();
   const { data: bloodlineData } = useSWR<BloodlineCardsResponse>(
-    user?.id ? "/api/bloodline-cards" : null
+    user?.id ? "/api/bloodline-cards" : null,
   );
 
-  const [createAuction, { loading }] = useMutation<CreateAuctionResponse>("/api/auctions");
+  const [createAuction, { loading }] =
+    useMutation<CreateAuctionResponse>("/api/auctions");
   const watchedStartPrice = Number(watch("startPrice") || 0);
   const watchedEndAt = watch("endAt");
   const currentBidIncrement = getBidIncrement(watchedStartPrice);
   const extensionMinutes = Math.floor(AUCTION_EXTENSION_MS / (60 * 1000));
   const extensionWindowMinutes = Math.floor(
-    AUCTION_EXTENSION_WINDOW_MS / (60 * 1000)
+    AUCTION_EXTENSION_WINDOW_MS / (60 * 1000),
   );
-  const subcategories = selectedCategory ? getSubcategories(selectedCategory) : [];
-  const bloodlineOptions =
-    (bloodlineData?.myBloodlines?.length
+  const subcategories = selectedCategory
+    ? getSubcategories(selectedCategory)
+    : [];
+  const bloodlineOptions = (
+    bloodlineData?.myBloodlines?.length
       ? bloodlineData.myBloodlines
       : bloodlineData?.ownedCards || []
-    ).filter((card) => card.cardType === "BLOODLINE");
+  ).filter((card) => card.cardType === "BLOODLINE");
 
   const customErrorMessages = [
     customFieldErrors.photos,
@@ -178,19 +192,19 @@ const CreateAuctionClient = () => {
   ].filter((message): message is string => Boolean(message));
 
   const isToolRoute = pathname?.startsWith("/tool");
-  const withBasePath = (path: string) =>
-    isToolRoute ? `/tool${path}` : path;
+  const withBasePath = (path: string) => (isToolRoute ? `/tool${path}` : path);
   const categoryForSubmit = isToolRoute
     ? TOOL_FIXED_CATEGORY
     : selectedSubcategory || selectedCategory;
   const loginPath = isToolRoute ? "/tool/login" : "/auth/login";
   const loginHref = `${loginPath}?next=${encodeURIComponent(
-    withBasePath("/auctions/create")
+    withBasePath("/auctions/create"),
   )}`;
 
   useEffect(() => {
     if (!isToolRoute) return;
-    if (selectedCategory === TOOL_FIXED_CATEGORY && !selectedSubcategory) return;
+    if (selectedCategory === TOOL_FIXED_CATEGORY && !selectedSubcategory)
+      return;
     setSelectedCategory(TOOL_FIXED_CATEGORY);
     setSelectedSubcategory("");
     setCustomFieldErrors((prev) => ({ ...prev, category: undefined }));
@@ -210,33 +224,39 @@ const CreateAuctionClient = () => {
     return (
       <Layout canGoBack title="경매 생성하기" seoTitle="경매 생성하기">
         <div className="relative min-h-[68vh] px-4 pt-6">
-          <div className="rounded-xl border border-slate-200 bg-slate-50 p-4">
-            <p className="text-sm font-semibold text-slate-900">경매 등록 안내</p>
+          <div className="rounded-lg border border-slate-200 bg-white p-4">
+            <p className="text-sm font-semibold text-slate-900">
+              경매 등록 안내
+            </p>
             <p className="mt-1.5 text-sm leading-relaxed text-slate-600">
-              경매 등록은 카카오 로그인 사용자만 가능합니다.
-              로그인 후 바로 등록 화면으로 이동합니다.
+              경매 등록은 카카오 로그인 사용자만 가능합니다. 로그인 후 바로 등록
+              화면으로 이동합니다.
             </p>
           </div>
         </div>
         <div className="fixed inset-0 z-[80] flex items-center justify-center p-4">
           <div className="absolute inset-0 bg-black/45" />
-          <div className="relative w-full max-w-sm rounded-2xl border border-slate-200 bg-white p-5 shadow-2xl">
-            <h2 className="text-lg font-bold text-slate-900">로그인이 필요합니다</h2>
+          <div className="relative w-full max-w-sm rounded-lg border border-slate-200 bg-white p-5 shadow-xl">
+            <h2 className="text-lg font-bold text-slate-900">
+              로그인이 필요합니다
+            </h2>
             <p className="mt-2 text-sm leading-relaxed text-slate-600">
-              경매 등록은 카카오 계정으로만 진행할 수 있습니다.
-              지금 로그인하면 경매 등록 화면으로 바로 이동합니다.
+              경매 등록은 카카오 계정으로만 진행할 수 있습니다. 지금 로그인하면
+              경매 등록 화면으로 바로 이동합니다.
             </p>
             <div className="mt-4 grid gap-2">
               <Link
                 href={loginHref}
-                className="inline-flex h-11 items-center justify-center rounded-xl bg-[#fee500] text-sm font-bold text-[#191919]"
+                className="inline-flex h-11 items-center justify-center rounded-lg bg-[#fee500] text-sm font-bold text-[#191919]"
               >
                 카카오 로그인하기
               </Link>
               <button
                 type="button"
-                onClick={() => router.push(isToolRoute ? "/tool" : withBasePath("/auctions"))}
-                className="h-11 rounded-xl border border-slate-200 bg-white text-sm font-semibold text-slate-700"
+                onClick={() =>
+                  router.push(isToolRoute ? "/tool" : withBasePath("/auctions"))
+                }
+                className="h-11 rounded-lg border border-slate-200 bg-white text-sm font-semibold text-slate-700"
               >
                 {isToolRoute ? "도구 홈으로 가기" : "경매 목록으로 가기"}
               </button>
@@ -289,7 +309,9 @@ const CreateAuctionClient = () => {
     setPhotos((prev) => prev.filter((_, i) => i !== index));
   };
 
-  const handleTrustProofUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleTrustProofUpload = async (
+    e: React.ChangeEvent<HTMLInputElement>,
+  ) => {
     const file = e.target.files?.[0];
     if (!file) return;
 
@@ -328,23 +350,39 @@ const CreateAuctionClient = () => {
   /** 제출 */
   const scrollToFirstCustomError = (errors: CustomFieldErrors) => {
     if (errors.photos) {
-      photosSectionRef.current?.scrollIntoView({ behavior: "smooth", block: "center" });
+      photosSectionRef.current?.scrollIntoView({
+        behavior: "smooth",
+        block: "center",
+      });
       return;
     }
     if (errors.category) {
-      categorySectionRef.current?.scrollIntoView({ behavior: "smooth", block: "center" });
+      categorySectionRef.current?.scrollIntoView({
+        behavior: "smooth",
+        block: "center",
+      });
       return;
     }
     if (errors.agreement) {
-      agreementSectionRef.current?.scrollIntoView({ behavior: "smooth", block: "center" });
+      agreementSectionRef.current?.scrollIntoView({
+        behavior: "smooth",
+        block: "center",
+      });
       return;
     }
     if (errors.duration) {
-      durationSectionRef.current?.scrollIntoView({ behavior: "smooth", block: "center" });
+      durationSectionRef.current?.scrollIntoView({
+        behavior: "smooth",
+        block: "center",
+      });
     }
   };
 
-  const validateCustomRequiredFields = ({ showToast }: { showToast: boolean }) => {
+  const validateCustomRequiredFields = ({
+    showToast,
+  }: {
+    showToast: boolean;
+  }) => {
     const nextErrors: CustomFieldErrors = {};
 
     if (photos.length === 0) {
@@ -388,7 +426,9 @@ const CreateAuctionClient = () => {
       return;
     }
 
-    const normalizedEndAt = toIsoDateTimeValue(getPresetEndAtValue(selectedDuration));
+    const normalizedEndAt = toIsoDateTimeValue(
+      getPresetEndAtValue(selectedDuration),
+    );
     if (!normalizedEndAt) return;
 
     const requestData = {
@@ -397,7 +437,9 @@ const CreateAuctionClient = () => {
       description: normalizeSignatureText(data.description),
       endAt: normalizedEndAt,
       category: categoryForSubmit,
-      bloodlineRootId: selectedBloodlineRootId ? Number(selectedBloodlineRootId) : null,
+      bloodlineRootId: selectedBloodlineRootId
+        ? Number(selectedBloodlineRootId)
+        : null,
       photos,
       sellerProofImage,
       startPrice: Number(data.startPrice),
@@ -406,7 +448,9 @@ const CreateAuctionClient = () => {
     const signature = buildSubmissionSignature(requestData);
 
     if (lastCreatedSignature === signature) {
-      toast.error("동일한 내용의 경매는 다시 등록할 수 없습니다. 기존 경매를 공유하거나 수정해주세요.");
+      toast.error(
+        "동일한 내용의 경매는 다시 등록할 수 없습니다. 기존 경매를 공유하거나 수정해주세요.",
+      );
       if (createdAuctionId) {
         setShareModalOpen(true);
       }
@@ -442,7 +486,9 @@ const CreateAuctionClient = () => {
     const refreshedSignature = buildSubmissionSignature(refreshedRequestData);
 
     if (lastCreatedSignature === refreshedSignature) {
-      toast.error("동일한 내용의 경매는 다시 등록할 수 없습니다. 기존 경매를 공유하거나 수정해주세요.");
+      toast.error(
+        "동일한 내용의 경매는 다시 등록할 수 없습니다. 기존 경매를 공유하거나 수정해주세요.",
+      );
       return;
     }
 
@@ -458,7 +504,12 @@ const CreateAuctionClient = () => {
           setShareModalOpen(true);
           toast.success("경매가 등록되었습니다. SNS에 공유해보세요!");
         } else {
-          toast.error(getAuctionErrorMessage(result.errorCode, result.error || "등록에 실패했습니다."));
+          toast.error(
+            getAuctionErrorMessage(
+              result.errorCode,
+              result.error || "등록에 실패했습니다.",
+            ),
+          );
         }
       },
       onError() {
@@ -533,7 +584,9 @@ const CreateAuctionClient = () => {
         return;
       }
       await copyToClipboard(url);
-      toast.info("이 기기에서는 바로 공유를 지원하지 않아 링크를 복사했습니다.");
+      toast.info(
+        "이 기기에서는 바로 공유를 지원하지 않아 링크를 복사했습니다.",
+      );
     } catch (error) {
       if (error instanceof Error && error.name === "AbortError") return;
       toast.error("공유에 실패했습니다.");
@@ -549,12 +602,17 @@ const CreateAuctionClient = () => {
 
   return (
     <Layout canGoBack title="경매 생성하기" seoTitle="경매 생성하기">
-      <form onSubmit={handleSubmit(onSubmit, onInvalid)} className="px-4 py-4 space-y-6 pb-28">
+      <form
+        onSubmit={handleSubmit(onSubmit, onInvalid)}
+        className="px-4 py-4 space-y-6 pb-28"
+      >
         {/* 이미지 업로드 */}
         <div ref={photosSectionRef}>
           <label className="block text-sm font-semibold text-gray-900 mb-2">
             사진 등록 <span className="text-red-500">*</span>
-            <span className="text-xs font-normal text-gray-400 ml-1">({photos.length}/5)</span>
+            <span className="text-xs font-normal text-gray-400 ml-1">
+              ({photos.length}/5)
+            </span>
           </label>
           <div className="flex gap-2 overflow-x-auto pb-2">
             {/* 추가 버튼 */}
@@ -570,15 +628,28 @@ const CreateAuctionClient = () => {
                 {uploading ? (
                   <div className="w-5 h-5 border-2 border-primary border-t-transparent rounded-full animate-spin" />
                 ) : (
-                  <svg className="w-6 h-6 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
+                  <svg
+                    className="w-6 h-6 text-gray-400"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth="2"
+                      d="M12 6v6m0 0v6m0-6h6m-6 0H6"
+                    />
                   </svg>
                 )}
               </label>
             )}
             {/* 미리보기 */}
             {photos.map((photo, i) => (
-              <div key={photo} className="relative flex-shrink-0 w-20 h-20 rounded-lg overflow-hidden">
+              <div
+                key={photo}
+                className="relative flex-shrink-0 w-20 h-20 rounded-lg overflow-hidden"
+              >
                 <Image
                   src={makeImageUrl(photo, "avatar")}
                   className="w-full h-full object-cover"
@@ -591,15 +662,27 @@ const CreateAuctionClient = () => {
                   onClick={() => handleRemoveImage(i)}
                   className="absolute top-1 right-1 w-5 h-5 bg-black/60 rounded-full flex items-center justify-center"
                 >
-                  <svg className="w-3 h-3 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M6 18L18 6M6 6l12 12" />
+                  <svg
+                    className="w-3 h-3 text-white"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth="2"
+                      d="M6 18L18 6M6 6l12 12"
+                    />
                   </svg>
                 </button>
               </div>
             ))}
           </div>
           {customFieldErrors.photos ? (
-            <p className="mt-1 text-xs text-red-500">{customFieldErrors.photos}</p>
+            <p className="mt-1 text-xs text-red-500">
+              {customFieldErrors.photos}
+            </p>
           ) : null}
         </div>
 
@@ -609,64 +692,73 @@ const CreateAuctionClient = () => {
             카테고리 <span className="text-red-500">*</span>
           </label>
           {isToolRoute ? (
-            <div className="inline-flex rounded-full bg-gray-900 px-3 py-1.5 text-sm font-medium text-white">
+            <div className="inline-flex rounded-lg bg-gray-900 px-3 py-1.5 text-sm font-medium text-white">
               {TOOL_FIXED_CATEGORY}
             </div>
           ) : (
             <>
-            <div className="flex flex-wrap gap-2">
-              {TOP_LEVEL_CATEGORIES.map((cat) => (
-                <button
-                  key={cat.id}
-                  type="button"
-                  onClick={() => {
-                    setSelectedCategory(cat.id);
-                    setSelectedSubcategory("");
-                    setCustomFieldErrors((prev) => ({ ...prev, category: undefined }));
-                  }}
-                  className={cn(
-                    "px-3 py-1.5 rounded-full text-sm font-medium transition-colors",
-                    selectedCategory === cat.id
-                      ? "bg-gray-900 text-white"
-                      : "bg-gray-100 text-gray-600 hover:bg-gray-200"
-                  )}
-                >
-                  {cat.name}
-                </button>
-              ))}
-            </div>
-            {subcategories.length > 0 ? (
-              <div className="mt-2 flex flex-wrap gap-2">
-                {subcategories.map((subcategory) => (
+              <div className="flex flex-wrap gap-2">
+                {TOP_LEVEL_CATEGORIES.map((cat) => (
                   <button
-                    key={subcategory}
+                    key={cat.id}
                     type="button"
                     onClick={() => {
-                      setSelectedSubcategory(subcategory);
-                      setCustomFieldErrors((prev) => ({ ...prev, category: undefined }));
+                      setSelectedCategory(cat.id);
+                      setSelectedSubcategory("");
+                      setCustomFieldErrors((prev) => ({
+                        ...prev,
+                        category: undefined,
+                      }));
                     }}
                     className={cn(
-                      "rounded-full border px-3 py-1 text-xs font-medium transition-colors",
-                      selectedSubcategory === subcategory
-                        ? "border-primary bg-primary text-white"
-                        : "border-slate-200 bg-white text-slate-500 hover:bg-slate-50"
+                      "rounded-lg border px-3 py-1.5 text-sm font-semibold transition-colors",
+                      selectedCategory === cat.id
+                        ? "border-gray-900 bg-gray-900 text-white"
+                        : "border-gray-200 bg-white text-gray-600 hover:bg-gray-50",
                     )}
                   >
-                    {subcategory}
+                    {cat.name}
                   </button>
                 ))}
               </div>
-            ) : null}
+              {subcategories.length > 0 ? (
+                <div className="mt-2 flex flex-wrap gap-2">
+                  {subcategories.map((subcategory) => (
+                    <button
+                      key={subcategory}
+                      type="button"
+                      onClick={() => {
+                        setSelectedSubcategory(subcategory);
+                        setCustomFieldErrors((prev) => ({
+                          ...prev,
+                          category: undefined,
+                        }));
+                      }}
+                      className={cn(
+                        "rounded-lg border px-3 py-1 text-xs font-semibold transition-colors",
+                        selectedSubcategory === subcategory
+                          ? "border-primary bg-primary text-white"
+                          : "border-slate-200 bg-white text-slate-500 hover:bg-slate-50",
+                      )}
+                    >
+                      {subcategory}
+                    </button>
+                  ))}
+                </div>
+              ) : null}
             </>
           )}
           {customFieldErrors.category ? (
-            <p className="mt-1 text-xs text-red-500">{customFieldErrors.category}</p>
+            <p className="mt-1 text-xs text-red-500">
+              {customFieldErrors.category}
+            </p>
           ) : null}
         </div>
 
         <div>
           <label className="mb-2 block text-sm font-semibold text-gray-900">
-            연결 혈통카드 <span className="text-xs font-normal text-gray-400">(선택)</span>
+            연결 혈통카드{" "}
+            <span className="text-xs font-normal text-gray-400">(선택)</span>
           </label>
           <select
             value={selectedBloodlineRootId}
@@ -711,7 +803,9 @@ const CreateAuctionClient = () => {
             rows={5}
           />
           {errors.description && (
-            <p className="text-xs text-red-500 mt-1">{errors.description.message}</p>
+            <p className="text-xs text-red-500 mt-1">
+              {errors.description.message}
+            </p>
           )}
         </div>
 
@@ -740,10 +834,14 @@ const CreateAuctionClient = () => {
               placeholder="10000"
               className="pr-8"
             />
-            <span className="absolute right-3 top-1/2 -translate-y-1/2 text-sm text-gray-400">원</span>
+            <span className="absolute right-3 top-1/2 -translate-y-1/2 text-sm text-gray-400">
+              원
+            </span>
           </div>
           {errors.startPrice && (
-            <p className="text-xs text-red-500 mt-1">{errors.startPrice.message}</p>
+            <p className="text-xs text-red-500 mt-1">
+              {errors.startPrice.message}
+            </p>
           )}
           <p className="text-xs text-gray-500 mt-1">
             자동 입찰 단위: {currentBidIncrement.toLocaleString()}원
@@ -752,10 +850,12 @@ const CreateAuctionClient = () => {
 
         <div
           ref={agreementSectionRef}
-          className="rounded-xl border border-slate-200 bg-slate-50 px-3.5 py-3"
+          className="rounded-lg border border-slate-200 bg-white px-3.5 py-3"
         >
           <div className="flex items-center justify-between gap-3">
-            <p className="text-sm font-semibold text-slate-800">경매 규칙 안내</p>
+            <p className="text-sm font-semibold text-slate-800">
+              경매 규칙 안내
+            </p>
             {!isToolRoute ? (
               <Link
                 href="/auctions/rules"
@@ -767,17 +867,26 @@ const CreateAuctionClient = () => {
           </div>
           <ul className="mt-2 space-y-1 text-xs text-slate-600">
             <li>• 입찰 단위는 현재가에 따라 자동 계산됩니다.</li>
-            <li>• 마감 {extensionWindowMinutes}분 이내 입찰 시 경매 시간이 {extensionMinutes}분 연장됩니다.</li>
+            <li>
+              • 마감 {extensionWindowMinutes}분 이내 입찰 시 경매 시간이{" "}
+              {extensionMinutes}분 연장됩니다.
+            </li>
             <li>• 본인 경매에는 입찰할 수 없습니다.</li>
-            <li>• 진행중 상태에서 등록 후 10분 이내, 입찰이 없을 때만 수정할 수 있습니다.</li>
+            <li>
+              • 진행중 상태에서 등록 후 10분 이내, 입찰이 없을 때만 수정할 수
+              있습니다.
+            </li>
             <li>• 동시 진행 경매는 계정당 최대 3개까지 등록 가능합니다.</li>
-            <li>• 시작가 50만원 이상 경매는 연락처(전화/이메일) 정보가 필요합니다.</li>
+            <li>
+              • 시작가 50만원 이상 경매는 연락처(전화/이메일) 정보가 필요합니다.
+            </li>
           </ul>
           <div className="mt-3 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2.5 text-xs text-amber-900">
             <p className="font-semibold">거래/분쟁 안내</p>
             <p className="mt-1 leading-relaxed">
-              본 서비스는 경매 중개 플랫폼이며, 거래 당사자 간 분쟁(허위 매물, 미발송, 환불 등)에 대해 법적 책임을 지지 않습니다.
-              다만 문제 발생 시 신고를 접수하여 운영정책에 따라 계정/콘텐츠 조치를 진행합니다.
+              본 서비스는 경매 중개 플랫폼이며, 거래 당사자 간 분쟁(허위 매물,
+              미발송, 환불 등)에 대해 법적 책임을 지지 않습니다. 다만 문제 발생
+              시 신고를 접수하여 운영정책에 따라 계정/콘텐츠 조치를 진행합니다.
             </p>
             <p className="mt-1 leading-relaxed font-semibold">
               카카오 로그인 기반 계정은 위반 시 영구 참여 제한됩니다.
@@ -800,12 +909,17 @@ const CreateAuctionClient = () => {
                   const checked = event.target.checked;
                   setAgreedAuctionNotice(checked);
                   if (checked && agreedDisputePolicy) {
-                    setCustomFieldErrors((prev) => ({ ...prev, agreement: undefined }));
+                    setCustomFieldErrors((prev) => ({
+                      ...prev,
+                      agreement: undefined,
+                    }));
                   }
                 }}
                 className="mt-0.5"
               />
-              <span>경매 규칙(입찰 단위, 연장, 수정 가능 조건)을 확인했습니다.</span>
+              <span>
+                경매 규칙(입찰 단위, 연장, 수정 가능 조건)을 확인했습니다.
+              </span>
             </label>
             <label className="flex items-start gap-2 text-xs text-slate-700">
               <input
@@ -815,7 +929,10 @@ const CreateAuctionClient = () => {
                   const checked = event.target.checked;
                   setAgreedDisputePolicy(checked);
                   if (agreedAuctionNotice && checked) {
-                    setCustomFieldErrors((prev) => ({ ...prev, agreement: undefined }));
+                    setCustomFieldErrors((prev) => ({
+                      ...prev,
+                      agreement: undefined,
+                    }));
                   }
                 }}
                 className="mt-0.5"
@@ -824,43 +941,41 @@ const CreateAuctionClient = () => {
             </label>
           </div>
           {customFieldErrors.agreement ? (
-            <p className="mt-2 text-xs text-red-500">{customFieldErrors.agreement}</p>
+            <p className="mt-2 text-xs text-red-500">
+              {customFieldErrors.agreement}
+            </p>
           ) : null}
         </div>
 
-        <div className="rounded-xl border border-slate-200 bg-white p-3.5">
-          <h3 className="text-sm font-semibold text-slate-900">판매자 신뢰 정보 (선택)</h3>
+        <div className="rounded-lg border border-slate-200 bg-white p-3.5">
+          <h3 className="text-sm font-semibold text-slate-900">
+            판매자 신뢰 정보 (선택)
+          </h3>
           <p className="mt-1 text-xs text-slate-500">
-            카페/밴드/블로그에서 신뢰 확인할 수 있는 정보를 함께 올리면 입찰 전환율이 높아집니다.
+            카페/밴드/블로그에서 신뢰 확인할 수 있는 정보를 함께 올리면 입찰
+            전환율이 높아집니다.
           </p>
           <div className="mt-3 grid grid-cols-1 gap-2.5">
             <Input
               {...register("sellerPhone")}
               placeholder="연락처(전화번호)"
             />
-            <Input
-              {...register("sellerEmail")}
-              placeholder="연락 이메일"
-            />
+            <Input {...register("sellerEmail")} placeholder="연락 이메일" />
             <Input
               {...register("sellerBlogUrl")}
               placeholder="블로그/프로필 URL"
             />
-            <Input
-              {...register("sellerCafeNick")}
-              placeholder="카페 닉네임"
-            />
-            <Input
-              {...register("sellerBandNick")}
-              placeholder="밴드 닉네임"
-            />
+            <Input {...register("sellerCafeNick")} placeholder="카페 닉네임" />
+            <Input {...register("sellerBandNick")} placeholder="밴드 닉네임" />
             <Textarea
               {...register("sellerTrustNote")}
               rows={3}
               placeholder="예: OO카페 활동 4년, 최근 3개월 거래 20건 무분쟁"
             />
             <div className="rounded-lg border border-slate-200 p-2.5">
-              <p className="text-xs font-medium text-slate-700">커뮤니티 프로필 캡처 (선택)</p>
+              <p className="text-xs font-medium text-slate-700">
+                커뮤니티 프로필 캡처 (선택)
+              </p>
               <p className="mt-0.5 text-[11px] text-slate-500">
                 카페/밴드 프로필 캡처를 올리면 신뢰도 안내에 표시됩니다.
               </p>
@@ -910,10 +1025,10 @@ const CreateAuctionClient = () => {
                 type="button"
                 onClick={() => handleDurationPreset(preset.hours)}
                 className={cn(
-                  "px-3 py-1.5 rounded-full text-sm font-medium transition-colors",
+                  "rounded-lg border px-3 py-1.5 text-sm font-semibold transition-colors",
                   selectedDuration === preset.hours
-                    ? "bg-gray-900 text-white"
-                    : "bg-gray-100 text-gray-600 hover:bg-gray-200"
+                    ? "border-gray-900 bg-gray-900 text-white"
+                    : "border-gray-200 bg-white text-gray-600 hover:bg-gray-50",
                 )}
               >
                 {preset.label}
@@ -938,7 +1053,9 @@ const CreateAuctionClient = () => {
             경매 종료 시간은 프리셋 버튼으로만 설정할 수 있습니다.
           </p>
           {customFieldErrors.duration ? (
-            <p className="mt-1 text-xs text-red-500">{customFieldErrors.duration}</p>
+            <p className="mt-1 text-xs text-red-500">
+              {customFieldErrors.duration}
+            </p>
           ) : null}
         </div>
 
@@ -953,7 +1070,7 @@ const CreateAuctionClient = () => {
             <Button
               type="submit"
               disabled={loading || uploading || proofUploading}
-              className="w-full h-12 text-base font-semibold rounded-xl"
+              className="h-12 w-full rounded-lg text-base font-semibold"
             >
               {loading ? "등록 중..." : "경매 등록하기"}
             </Button>
@@ -969,21 +1086,31 @@ const CreateAuctionClient = () => {
             onClick={handleCancelConfirm}
             aria-label="등록 확인 팝업 닫기"
           />
-          <div className="relative w-full max-w-sm rounded-2xl border border-slate-200 bg-white p-5 shadow-2xl">
-            <h2 className="text-lg font-bold text-slate-900">정말 이 내용으로 등록하시겠습니까?</h2>
+          <div className="relative w-full max-w-sm rounded-lg border border-slate-200 bg-white p-5 shadow-xl">
+            <h2 className="text-lg font-bold text-slate-900">
+              정말 이 내용으로 등록하시겠습니까?
+            </h2>
             <p className="mt-2 text-sm leading-relaxed text-slate-600">
-              등록 후에는 동일 내용 재등록이 제한될 수 있습니다. 가격과 시간을 다시 확인해주세요.
+              등록 후에는 동일 내용 재등록이 제한될 수 있습니다. 가격과 시간을
+              다시 확인해주세요.
             </p>
 
-            <div className="mt-4 space-y-2 rounded-xl border border-slate-200 bg-slate-50 p-3">
+            <div className="mt-4 space-y-2 rounded-lg border border-slate-200 bg-slate-50 p-3">
               <div className="flex items-center justify-between">
-                <span className="text-xs font-medium text-slate-500">시작가</span>
+                <span className="text-xs font-medium text-slate-500">
+                  시작가
+                </span>
                 <span className="text-base font-bold text-slate-900">
-                  {Number(pendingSubmission.requestData.startPrice).toLocaleString()}원
+                  {Number(
+                    pendingSubmission.requestData.startPrice,
+                  ).toLocaleString()}
+                  원
                 </span>
               </div>
               <div className="flex items-center justify-between">
-                <span className="text-xs font-medium text-slate-500">종료 시간</span>
+                <span className="text-xs font-medium text-slate-500">
+                  종료 시간
+                </span>
                 <span className="text-sm font-semibold text-slate-800">
                   {formatConfirmDateTime(pendingSubmission.requestData.endAt)}
                 </span>
@@ -995,7 +1122,7 @@ const CreateAuctionClient = () => {
                 type="button"
                 onClick={handleCancelConfirm}
                 disabled={loading}
-                className="h-11 rounded-xl border border-slate-200 bg-white text-sm font-semibold text-slate-700 transition-colors hover:bg-slate-50 disabled:opacity-60"
+                className="h-11 rounded-lg border border-slate-200 bg-white text-sm font-semibold text-slate-700 transition-colors hover:bg-slate-50 disabled:opacity-60"
               >
                 다시 확인
               </button>
@@ -1003,7 +1130,7 @@ const CreateAuctionClient = () => {
                 type="button"
                 onClick={handleConfirmCreate}
                 disabled={loading}
-                className="h-11 rounded-xl bg-slate-900 text-sm font-semibold text-white transition-colors hover:bg-slate-800 disabled:opacity-60"
+                className="h-11 rounded-lg bg-slate-900 text-sm font-semibold text-white transition-colors hover:bg-slate-800 disabled:opacity-60"
               >
                 {loading ? "등록 중..." : "이대로 등록"}
               </button>
@@ -1020,8 +1147,10 @@ const CreateAuctionClient = () => {
             onClick={() => setShareModalOpen(false)}
             aria-label="공유 팝업 닫기"
           />
-          <div className="relative w-full max-w-sm rounded-2xl border border-slate-200 bg-white p-5 shadow-2xl">
-            <h2 className="text-lg font-bold text-slate-900">생성한 경매를 SNS에 공유해보세요!</h2>
+          <div className="relative w-full max-w-sm rounded-lg border border-slate-200 bg-white p-5 shadow-xl">
+            <h2 className="text-lg font-bold text-slate-900">
+              생성한 경매를 SNS에 공유해보세요!
+            </h2>
             <p className="mt-2 text-sm leading-relaxed text-slate-600">
               지금 공유하면 더 빠르게 입찰자를 모을 수 있어요.
             </p>
@@ -1029,21 +1158,21 @@ const CreateAuctionClient = () => {
               <button
                 type="button"
                 onClick={handleCopyAuctionLink}
-                className="h-11 rounded-xl border border-slate-200 bg-white text-sm font-semibold text-slate-700 transition-colors hover:bg-slate-50"
+                className="h-11 rounded-lg border border-slate-200 bg-white text-sm font-semibold text-slate-700 transition-colors hover:bg-slate-50"
               >
                 링크 복사하기
               </button>
               <button
                 type="button"
                 onClick={handleShareAuction}
-                className="h-11 rounded-xl bg-slate-900 text-sm font-semibold text-white transition-colors hover:bg-slate-800"
+                className="h-11 rounded-lg bg-slate-900 text-sm font-semibold text-white transition-colors hover:bg-slate-800"
               >
                 바로 공유하기
               </button>
               <button
                 type="button"
                 onClick={handleMoveToAuction}
-                className="h-11 rounded-xl bg-[#fee500] text-sm font-bold text-[#191919] transition-colors hover:brightness-95"
+                className="h-11 rounded-lg bg-[#fee500] text-sm font-bold text-[#191919] transition-colors hover:brightness-95"
               >
                 경매 상세로 이동
               </button>

--- a/app/(web)/bloodline-cards/create/BloodlineCardCreateClient.tsx
+++ b/app/(web)/bloodline-cards/create/BloodlineCardCreateClient.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { ChangeEvent, FormEvent, useEffect, useMemo, useRef, useState } from "react";
+import {
+  ChangeEvent,
+  FormEvent,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import Layout from "@components/features/MainLayout";
@@ -17,7 +24,10 @@ import {
 } from "@components/features/bloodline/BloodlineVisualCard";
 import { cn } from "@libs/client/utils";
 
-const CARD_VARIANT_LABELS: { value: BloodlineVisualCardVariant; label: string }[] = [
+const CARD_VARIANT_LABELS: {
+  value: BloodlineVisualCardVariant;
+  label: string;
+}[] = [
   { value: "noir", label: "모던" },
   { value: "clean", label: "클린" },
   { value: "editorial", label: "에디토리얼" },
@@ -27,7 +37,14 @@ const allowedNamePattern = /^[A-Za-z0-9가-힣]+$/;
 
 const CARD_VARIANT_STORAGE_KEY = "bloodline.visual.card.variant";
 const MAX_IMAGE_SIZE = 10 * 1024 * 1024;
-const ALLOWED_IMAGE_EXTENSIONS = [".jpg", ".jpeg", ".png", ".webp", ".heic", ".heif"] as const;
+const ALLOWED_IMAGE_EXTENSIONS = [
+  ".jpg",
+  ".jpeg",
+  ".png",
+  ".webp",
+  ".heic",
+  ".heif",
+] as const;
 
 const getFileExtension = (name: string) => {
   const pointIndex = name.lastIndexOf(".");
@@ -59,10 +76,13 @@ export default function BloodlineCardCreateClient() {
 
   const previewName = useMemo(
     () => (cardName.trim() || "새 혈통").slice(0, 40),
-    [cardName]
+    [cardName],
   );
 
-  const previewImageUrl = useMemo(() => cardImagePreview || "", [cardImagePreview]);
+  const previewImageUrl = useMemo(
+    () => cardImagePreview || "",
+    [cardImagePreview],
+  );
 
   useEffect(() => {
     if (!cardImageFile) {
@@ -79,7 +99,9 @@ export default function BloodlineCardCreateClient() {
       const saved = localStorage.getItem(CARD_VARIANT_STORAGE_KEY);
       if (
         saved &&
-        bloodlineVisualCardVariants.includes(saved as BloodlineVisualCardVariant)
+        bloodlineVisualCardVariants.includes(
+          saved as BloodlineVisualCardVariant,
+        )
       ) {
         setCardVisualVariant(saved as BloodlineVisualCardVariant);
       }
@@ -160,7 +182,9 @@ export default function BloodlineCardCreateClient() {
     const nextExt = getFileExtension(nextFile.name || "").toLowerCase();
     const isImageTypeAllowed =
       nextType.startsWith("image/") ||
-      ALLOWED_IMAGE_EXTENSIONS.includes(nextExt as (typeof ALLOWED_IMAGE_EXTENSIONS)[number]);
+      ALLOWED_IMAGE_EXTENSIONS.includes(
+        nextExt as (typeof ALLOWED_IMAGE_EXTENSIONS)[number],
+      );
 
     if (!isImageTypeAllowed) {
       setImageError("이미지 파일만 업로드할 수 있습니다.");
@@ -213,7 +237,9 @@ export default function BloodlineCardCreateClient() {
       return;
     }
     if (!allowedNamePattern.test(nextName)) {
-      setNameError("이름은 영문, 숫자, 한글만 입력 가능하며 공백/특수문자는 허용되지 않습니다.");
+      setNameError(
+        "이름은 영문, 숫자, 한글만 입력 가능하며 공백/특수문자는 허용되지 않습니다.",
+      );
       return;
     }
     if (!nextDescription) {
@@ -221,7 +247,9 @@ export default function BloodlineCardCreateClient() {
       return;
     }
 
-    const isConfirmed = window.confirm(`"${nextName}" 혈통카드를 정말로 만드시겠어요?`);
+    const isConfirmed = window.confirm(
+      `"${nextName}" 혈통카드를 정말로 만드시겠어요?`,
+    );
     if (!isConfirmed) {
       return;
     }
@@ -232,7 +260,11 @@ export default function BloodlineCardCreateClient() {
         setMessage("카드 이미지 업로드 중...");
       }
       const image = cardImageFile ? await uploadCardImage(cardImageFile) : "";
-      setMessage(cardImageFile ? "이미지 업로드 완료. 카드 생성 중..." : "카드 생성 중...");
+      setMessage(
+        cardImageFile
+          ? "이미지 업로드 완료. 카드 생성 중..."
+          : "카드 생성 중...",
+      );
 
       const res = await fetch("/api/bloodline-cards", {
         method: "POST",
@@ -250,7 +282,9 @@ export default function BloodlineCardCreateClient() {
         throw new Error(errorMessage);
       }
       if (!payload.success) {
-        throw new Error(errorMessage || payload.error || "혈통카드 생성에 실패했습니다.");
+        throw new Error(
+          errorMessage || payload.error || "혈통카드 생성에 실패했습니다.",
+        );
       }
 
       const createdCardId =
@@ -270,7 +304,9 @@ export default function BloodlineCardCreateClient() {
       }
       setMessage("");
       const encodedCardName = encodeURIComponent(nextName);
-      router.push(`/bloodline-management/card/${createdCardId}?celebration=card-created&name=${encodedCardName}`);
+      router.push(
+        `/bloodline-management/card/${createdCardId}?celebration=card-created&name=${encodedCardName}`,
+      );
     } catch (createError) {
       const errorMessage =
         createError instanceof Error
@@ -287,11 +323,20 @@ export default function BloodlineCardCreateClient() {
   };
 
   return (
-    <Layout canGoBack showHome title="혈통카드 만들기" seoTitle="혈통카드 만들기">
-      <div className={`relative space-y-4 px-4 py-4 pb-12 ${creatingCard ? "pointer-events-none" : ""}`}>
+    <Layout
+      canGoBack
+      showHome
+      title="혈통카드 만들기"
+      seoTitle="혈통카드 만들기"
+    >
+      <div
+        className={`relative space-y-4 px-4 py-4 pb-12 ${
+          creatingCard ? "pointer-events-none" : ""
+        }`}
+      >
         {creatingCard ? (
           <div className="fixed inset-0 z-40 grid place-items-center bg-white/80">
-            <div className="rounded-xl border border-slate-200 bg-white px-5 py-4 shadow-md">
+            <div className="rounded-lg border border-slate-200 bg-white px-5 py-4 shadow-sm">
               <div className="flex flex-col items-center gap-3">
                 <Spinner />
                 <p className="text-center text-sm font-semibold text-slate-800">
@@ -301,20 +346,25 @@ export default function BloodlineCardCreateClient() {
             </div>
           </div>
         ) : null}
-        <section className="app-reveal app-reveal-1 relative overflow-hidden rounded-2xl border border-slate-200/80 bg-gradient-to-br from-white/90 via-slate-50 to-slate-50 p-4 shadow-[0_15px_40px_rgba(15, 23, 42,0.18)] transition duration-300 hover:-translate-y-0.5 hover:shadow-[0_18px_40px_rgba(15, 23, 42,0.24)]">
-          <div className="pointer-events-none absolute -left-20 -bottom-16 h-36 w-36 rounded-full bg-slate-200/45 blur-2xl" />
+        <section className="app-reveal app-reveal-1 rounded-lg border border-slate-200 bg-white p-4">
           <div className="mb-3 flex items-start justify-between gap-3">
             <div>
-              <p className="text-xs font-black uppercase tracking-[0.16em] text-slate-500">대표 카드 미리보기</p>
-              <p className="mt-1 text-[13px] font-semibold text-slate-900">내가 상상한 혈통의 정수</p>
+              <p className="text-xs font-semibold text-primary">
+                대표 카드 미리보기
+              </p>
+              <p className="mt-1 text-[13px] font-semibold text-slate-900">
+                생성 전 카드 형태를 확인하세요
+              </p>
             </div>
-            <span className="shrink-0 rounded-full border border-slate-200 bg-white/80 px-2.5 py-1 text-[11px] font-semibold text-slate-700">
+            <span className="shrink-0 rounded-md border border-slate-200 bg-slate-50 px-2.5 py-1 text-[11px] font-semibold text-slate-700">
               LIVE
             </span>
           </div>
           <div className="mb-3">
             <div className="mb-2 flex items-center justify-between gap-2">
-              <p className="text-xs font-semibold text-slate-700">카드 스타일</p>
+              <p className="text-xs font-semibold text-slate-700">
+                카드 스타일
+              </p>
               <span className="text-[11px] text-slate-500">원클릭 적용</span>
             </div>
             <div className="grid grid-cols-3 gap-2">
@@ -323,7 +373,7 @@ export default function BloodlineCardCreateClient() {
                   key={item.value}
                   type="button"
                   onClick={() => setCardVisualVariant(item.value)}
-                  className={`h-9 rounded-full border px-3 text-[11px] font-semibold transition ${
+                  className={`h-9 rounded-lg border px-3 text-[11px] font-semibold transition ${
                     cardVisualVariant === item.value
                       ? "bg-slate-900 text-white"
                       : "bg-white text-slate-700 hover:border-slate-300 hover:bg-slate-50"
@@ -357,7 +407,9 @@ export default function BloodlineCardCreateClient() {
 
         {!isUserLoading && !user ? (
           <section className="rounded-xl border border-slate-200 bg-white p-5 text-center">
-            <p className="text-sm text-slate-700">혈통카드는 로그인 후 생성할 수 있습니다.</p>
+            <p className="text-sm text-slate-700">
+              혈통카드는 로그인 후 생성할 수 있습니다.
+            </p>
             <Link
               href="/auth/login?next=%2Fbloodline-cards%2Fcreate"
               className="mt-3 inline-flex h-10 items-center justify-center rounded-lg bg-slate-900 px-4 text-sm font-semibold text-white"
@@ -382,9 +434,11 @@ export default function BloodlineCardCreateClient() {
 
             <form
               onSubmit={handleCreateBloodlineCard}
-              className="app-reveal app-reveal-2 space-y-3 rounded-2xl border border-slate-200/80 bg-white/90 p-4 shadow-[0_12px_34px_rgba(15, 23, 42,0.14)] transition duration-300 hover:-translate-y-0.5 hover:shadow-[0_16px_40px_rgba(15, 23, 42,0.22)]"
+              className="app-reveal app-reveal-2 space-y-3 rounded-lg border border-slate-200 bg-white p-4"
             >
-              <h2 className="text-base font-black tracking-tight text-slate-900">혈통카드 생성</h2>
+              <h2 className="text-base font-black tracking-tight text-slate-900">
+                혈통카드 생성
+              </h2>
               <div className="space-y-1">
                 <Input
                   value={cardName}
@@ -397,14 +451,19 @@ export default function BloodlineCardCreateClient() {
                   placeholder="혈통 이름을 입력해주세요 (필수)"
                   className={cn(
                     "h-11 border-slate-200/70",
-                    nameError && "border-rose-300 focus-visible:ring-rose-200"
+                    nameError && "border-rose-300 focus-visible:ring-rose-200",
                   )}
                   disabled={creatingCard}
                   aria-invalid={Boolean(nameError)}
-                  aria-describedby={nameError ? "bloodline-card-name-error" : undefined}
+                  aria-describedby={
+                    nameError ? "bloodline-card-name-error" : undefined
+                  }
                 />
                 {nameError ? (
-                  <p id="bloodline-card-name-error" className="text-xs font-medium text-rose-600">
+                  <p
+                    id="bloodline-card-name-error"
+                    className="text-xs font-medium text-rose-600"
+                  >
                     {nameError}
                   </p>
                 ) : null}
@@ -422,11 +481,16 @@ export default function BloodlineCardCreateClient() {
                   placeholder="이 혈통카드의 소개를 적어주세요 (필수)"
                   className={cn(
                     "leading-relaxed",
-                    descriptionError && "border-rose-300 focus-visible:ring-rose-200"
+                    descriptionError &&
+                      "border-rose-300 focus-visible:ring-rose-200",
                   )}
                   disabled={creatingCard}
                   aria-invalid={Boolean(descriptionError)}
-                  aria-describedby={descriptionError ? "bloodline-card-description-error" : undefined}
+                  aria-describedby={
+                    descriptionError
+                      ? "bloodline-card-description-error"
+                      : undefined
+                  }
                 />
                 {descriptionError ? (
                   <p
@@ -442,7 +506,7 @@ export default function BloodlineCardCreateClient() {
                 <div
                   className={cn(
                     "rounded-lg border border-slate-200 bg-slate-50 p-3",
-                    imageError && "border-rose-200 bg-rose-50/40"
+                    imageError && "border-rose-200 bg-rose-50/40",
                   )}
                 >
                   <label
@@ -450,7 +514,7 @@ export default function BloodlineCardCreateClient() {
                     className={cn(
                       "inline-flex h-11 w-full cursor-pointer items-center justify-center rounded-lg border border-dashed border-slate-300 bg-white text-sm font-semibold text-slate-700 transition hover:bg-slate-50",
                       creatingCard && "pointer-events-none opacity-60",
-                      imageError && "border-rose-300"
+                      imageError && "border-rose-300",
                     )}
                   >
                     {cardImageFile ? "다른 이미지로 바꾸기" : "이미지 선택"}
@@ -476,7 +540,7 @@ export default function BloodlineCardCreateClient() {
                       <button
                         type="button"
                         onClick={handleRemoveImage}
-                        className="inline-flex h-8 items-center rounded-full bg-white px-3 text-xs font-semibold text-slate-700 transition hover:bg-slate-100"
+                        className="inline-flex h-8 items-center rounded-lg border border-slate-200 bg-white px-3 text-xs font-semibold text-slate-700 transition hover:bg-slate-50"
                         disabled={creatingCard}
                       >
                         삭제
@@ -485,7 +549,9 @@ export default function BloodlineCardCreateClient() {
                   ) : null}
                 </div>
                 {imageError ? (
-                  <p className="mt-1 text-xs font-medium text-rose-600">{imageError}</p>
+                  <p className="mt-1 text-xs font-medium text-rose-600">
+                    {imageError}
+                  </p>
                 ) : null}
                 <p className="text-[11px] text-slate-500">
                   JPG / PNG / WEBP, 최대 10MB. 이미지 첨부는 선택 항목입니다.

--- a/app/(web)/bloodline-management/BloodlineManagementClient.tsx
+++ b/app/(web)/bloodline-management/BloodlineManagementClient.tsx
@@ -36,20 +36,25 @@ const getSectionId = (key: SectionKey) => {
 };
 
 const cardTypeBadgeClass =
-  "inline-flex rounded-full bg-slate-100 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.1em]";
+  "inline-flex rounded-md bg-slate-100 px-2 py-0.5 text-[10px] font-semibold";
 
-const SECTION_KEYS: SectionKey[] = ["myBloodlines", "createdLines", "receivedCards"];
+const SECTION_KEYS: SectionKey[] = [
+  "myBloodlines",
+  "createdLines",
+  "receivedCards",
+];
 
 export default function BloodlineManagementClient() {
   const { user } = useUser();
   const searchParams = useSearchParams();
   const router = useRouter();
 
-  const { data: bloodlineData, isLoading: isBloodlineLoading } = useSWR<BloodlineCardsResponse>(
-    user?.id ? "/api/bloodline-cards" : null
-  );
+  const { data: bloodlineData, isLoading: isBloodlineLoading } =
+    useSWR<BloodlineCardsResponse>(user?.id ? "/api/bloodline-cards" : null);
 
-  const [expandedSections, setExpandedSections] = useState<Record<SectionKey, boolean>>({
+  const [expandedSections, setExpandedSections] = useState<
+    Record<SectionKey, boolean>
+  >({
     myBloodlines: false,
     createdLines: false,
     receivedCards: false,
@@ -59,10 +64,12 @@ export default function BloodlineManagementClient() {
     if (!bloodlineData) return [];
     if (bloodlineData.myBloodlines?.length) return bloodlineData.myBloodlines;
     if (bloodlineData.myCreatedCards?.length) {
-      return bloodlineData.myCreatedCards.filter((card) => card.cardType === "BLOODLINE");
+      return bloodlineData.myCreatedCards.filter(
+        (card) => card.cardType === "BLOODLINE",
+      );
     }
     return (bloodlineData.ownedCards || []).filter(
-      (card) => card.creator.id === user?.id && card.cardType === "BLOODLINE"
+      (card) => card.creator.id === user?.id && card.cardType === "BLOODLINE",
     );
   }, [bloodlineData, user?.id]);
 
@@ -70,21 +77,26 @@ export default function BloodlineManagementClient() {
     if (!bloodlineData) return [];
     if (bloodlineData.createdLines?.length) return bloodlineData.createdLines;
     if (bloodlineData.myCreatedCards?.length) {
-      return bloodlineData.myCreatedCards.filter((card) => card.cardType === "LINE");
+      return bloodlineData.myCreatedCards.filter(
+        (card) => card.cardType === "LINE",
+      );
     }
     return (bloodlineData.ownedCards || []).filter(
-      (card) => card.creator.id === user?.id && card.cardType === "LINE"
+      (card) => card.creator.id === user?.id && card.cardType === "LINE",
     );
   }, [bloodlineData, user?.id]);
 
   const receivedBloodlines = useMemo(() => {
     if (!bloodlineData) return [];
-    if (bloodlineData.receivedBloodlines?.length) return bloodlineData.receivedBloodlines;
+    if (bloodlineData.receivedBloodlines?.length)
+      return bloodlineData.receivedBloodlines;
     if (bloodlineData.receivedCards?.length) {
-      return bloodlineData.receivedCards.filter((card) => card.cardType === "BLOODLINE");
+      return bloodlineData.receivedCards.filter(
+        (card) => card.cardType === "BLOODLINE",
+      );
     }
     return (bloodlineData.ownedCards || []).filter(
-      (card) => card.creator.id !== user?.id && card.cardType === "BLOODLINE"
+      (card) => card.creator.id !== user?.id && card.cardType === "BLOODLINE",
     );
   }, [bloodlineData, user?.id]);
 
@@ -92,16 +104,18 @@ export default function BloodlineManagementClient() {
     if (!bloodlineData) return [];
     if (bloodlineData.receivedLines?.length) return bloodlineData.receivedLines;
     if (bloodlineData.receivedCards?.length) {
-      return bloodlineData.receivedCards.filter((card) => card.cardType === "LINE");
+      return bloodlineData.receivedCards.filter(
+        (card) => card.cardType === "LINE",
+      );
     }
     return (bloodlineData.ownedCards || []).filter(
-      (card) => card.creator.id !== user?.id && card.cardType === "LINE"
+      (card) => card.creator.id !== user?.id && card.cardType === "LINE",
     );
   }, [bloodlineData, user?.id]);
 
   const receivedCards = useMemo(
     () => [...receivedBloodlines, ...receivedLines],
-    [receivedBloodlines, receivedLines]
+    [receivedBloodlines, receivedLines],
   );
 
   const directCards = myBloodlines.length + createdLines.length;
@@ -139,7 +153,10 @@ export default function BloodlineManagementClient() {
     router.push(`/bloodline-management/card/${cardId}`);
   };
 
-  const handleCardKeyDown = (event: KeyboardEvent<HTMLElement>, cardId: number) => {
+  const handleCardKeyDown = (
+    event: KeyboardEvent<HTMLElement>,
+    cardId: number,
+  ) => {
     if (event.key === "Enter" || event.key === " ") {
       event.preventDefault();
       handleCardClick(cardId);
@@ -148,21 +165,27 @@ export default function BloodlineManagementClient() {
 
   const renderSection = (key: SectionKey, cards: BloodlineCardItem[]) => {
     const open = expandedSections[key];
-    const previewLimit = key === "receivedCards" ? RECEIVED_PREVIEW_LIMIT : PREVIEW_LIMIT;
+    const previewLimit =
+      key === "receivedCards" ? RECEIVED_PREVIEW_LIMIT : PREVIEW_LIMIT;
     const visibleCards = open ? cards : cards.slice(0, previewLimit);
     const hasMore = cards.length > previewLimit;
 
     return (
-      <section id={getSectionId(key)} className="space-y-3 rounded-xl bg-white p-4">
+      <section
+        id={getSectionId(key)}
+        className="space-y-3 rounded-lg border border-slate-200 bg-white p-4"
+      >
         <div className="flex items-center justify-between gap-2">
           <div>
             <h2 className="app-title-md">{sectionTitle[key]}</h2>
-            <p className="mt-1 text-xs font-semibold text-slate-500">총 {cards.length}개</p>
+            <p className="mt-1 text-xs font-semibold text-slate-500">
+              총 {cards.length}개
+            </p>
           </div>
           <div className="flex items-center gap-2">
             <Link
               href={sectionPagePath[key]}
-              className="inline-flex h-8 items-center rounded-full bg-slate-100 px-3 text-xs font-semibold text-slate-700 transition hover:bg-slate-200"
+              className="inline-flex h-8 items-center rounded-lg border border-slate-200 bg-white px-3 text-xs font-semibold text-slate-700 transition hover:bg-slate-50"
             >
               목록 이동
             </Link>
@@ -170,7 +193,7 @@ export default function BloodlineManagementClient() {
               <button
                 type="button"
                 onClick={() => toggleSection(key)}
-                className="inline-flex h-8 items-center rounded-full bg-white px-3 text-xs font-semibold text-slate-700 transition hover:bg-slate-50"
+                className="inline-flex h-8 items-center rounded-lg border border-slate-200 bg-white px-3 text-xs font-semibold text-slate-700 transition hover:bg-slate-50"
               >
                 {open ? "접기" : "모두 보기"}
               </button>
@@ -187,7 +210,7 @@ export default function BloodlineManagementClient() {
                 tabIndex={0}
                 onClick={() => handleCardClick(card.id)}
                 onKeyDown={(event) => handleCardKeyDown(event, card.id)}
-                className="cursor-pointer rounded-lg border border-slate-200 bg-white p-3 transition duration-150 hover:shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-300"
+                className="cursor-pointer rounded-lg border border-slate-200 bg-white p-3 transition duration-150 hover:border-slate-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-300"
               >
                 <BloodlineVisualCard
                   cardId={card.id}
@@ -200,10 +223,14 @@ export default function BloodlineManagementClient() {
                 />
                 <div className="mt-2 space-y-1">
                   <div className="flex items-start justify-between gap-2">
-                    <p className="line-clamp-1 text-sm font-bold text-slate-900">{card.name}</p>
+                    <p className="line-clamp-1 text-sm font-bold text-slate-900">
+                      {card.name}
+                    </p>
                     <span
                       className={`${cardTypeBadgeClass} ${
-                        card.cardType === "BLOODLINE" ? "bg-blue-50 text-blue-700" : "bg-emerald-50 text-emerald-700"
+                        card.cardType === "BLOODLINE"
+                          ? "bg-blue-50 text-blue-700"
+                          : "bg-emerald-50 text-emerald-700"
                       }`}
                     >
                       {card.cardType === "BLOODLINE" ? "혈통" : "라인"}
@@ -220,7 +247,9 @@ export default function BloodlineManagementClient() {
             ))}
           </div>
         ) : (
-          <p className="rounded-none bg-slate-50 p-4 text-sm text-slate-600">해당 항목의 카드가 없습니다.</p>
+          <p className="rounded-none bg-slate-50 p-4 text-sm text-slate-600">
+            해당 항목의 카드가 없습니다.
+          </p>
         )}
       </section>
     );
@@ -230,30 +259,39 @@ export default function BloodlineManagementClient() {
     <div className="app-page min-h-screen">
       <div className="mx-auto flex w-full max-w-[680px] flex-col gap-4">
         <header className="space-y-3">
-          <div className="rounded-xl border border-slate-200 bg-white p-4">
-            <p className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">
+          <div className="rounded-lg border border-slate-200 bg-white p-4">
+            <p className="text-xs font-semibold text-primary">
               BLOODLINE MANAGEMENT
             </p>
             <div className="mt-2 flex items-center justify-between gap-2">
               <h1 className="app-title-lg">혈통관리</h1>
               <Link
                 href="/bloodline-cards/create"
-                className="inline-flex h-9 items-center justify-center rounded-full bg-orange-500 px-3 text-xs font-semibold text-white shadow-sm transition hover:bg-orange-600"
+                className="inline-flex h-9 items-center justify-center rounded-lg bg-slate-900 px-3 text-xs font-semibold text-white transition hover:bg-slate-800"
               >
                 새 혈통 만들기
               </Link>
             </div>
             <p className="mt-1 text-sm text-slate-600">
-              카드를 선택하면 상세에서 보내기와 라인 만들기를 바로 이어서 진행할 수 있습니다.
+              카드를 선택하면 상세에서 보내기와 라인 만들기를 바로 이어서 진행할
+              수 있습니다.
             </p>
             <div className="mt-3 grid grid-cols-2 gap-2 text-sm">
               <div className="rounded-lg bg-slate-50 px-3 py-2">
-                <p className="text-[11px] font-semibold text-slate-500">총 자산</p>
-                <p className="mt-1 text-lg font-bold text-slate-900">{totalCards}개</p>
+                <p className="text-[11px] font-semibold text-slate-500">
+                  총 자산
+                </p>
+                <p className="mt-1 text-lg font-bold text-slate-900">
+                  {totalCards}개
+                </p>
               </div>
               <div className="rounded-lg bg-slate-50 px-3 py-2">
-                <p className="text-[11px] font-semibold text-slate-500">내 구성</p>
-                <p className="mt-1 text-lg font-bold text-slate-900">{directCards}개</p>
+                <p className="text-[11px] font-semibold text-slate-500">
+                  내 구성
+                </p>
+                <p className="mt-1 text-lg font-bold text-slate-900">
+                  {directCards}개
+                </p>
               </div>
             </div>
           </div>

--- a/app/(web)/bloodline-management/card/[cardId]/BloodlineCardDetailClient.tsx
+++ b/app/(web)/bloodline-management/card/[cardId]/BloodlineCardDetailClient.tsx
@@ -35,7 +35,7 @@ interface TransferUserItem {
   name: string;
 }
 
-const sectionClass = "rounded-xl border border-slate-200/80 bg-white p-4";
+const sectionClass = "rounded-lg border border-slate-200 bg-white p-4";
 const panelHeaderClass = "mb-3 flex items-center justify-between gap-2";
 const actionButtonClass =
   "inline-flex h-11 w-full items-center justify-center rounded-lg bg-slate-900 px-4 text-sm font-semibold text-white transition hover:bg-slate-800";
@@ -43,7 +43,7 @@ const accentButtonClass =
   "inline-flex h-11 w-full items-center justify-center rounded-lg bg-[hsl(var(--accent))] px-4 text-sm font-semibold text-[hsl(var(--accent-foreground))] transition hover:opacity-95";
 const cancelButtonClass =
   "inline-flex h-10 w-full items-center justify-center rounded-lg bg-white border border-slate-200 text-sm font-semibold text-slate-700 transition hover:bg-slate-50";
-const chipClass = "rounded-full bg-slate-100 px-2 py-1 text-xs text-slate-600";
+const chipClass = "rounded-md bg-slate-100 px-2 py-1 text-xs text-slate-600";
 const formatDate = (value: string) =>
   new Date(value).toLocaleString("ko-KR", {
     month: "short",
@@ -70,7 +70,9 @@ const eventToneByAction: Record<string, string> = {
   CARD_REVOKED: "border-rose-100 bg-rose-50 text-rose-700",
 };
 
-export default function BloodlineCardDetailClient({ cardId }: BloodlineCardDetailClientProps) {
+export default function BloodlineCardDetailClient({
+  cardId,
+}: BloodlineCardDetailClientProps) {
   const { user } = useUser();
   const router = useRouter();
   const pathname = usePathname();
@@ -89,10 +91,14 @@ export default function BloodlineCardDetailClient({ cardId }: BloodlineCardDetai
   const [issueLoading, setIssueLoading] = useState(false);
   const [message, setMessage] = useState("");
   const [error, setError] = useState("");
-  const [events, setEvents] = useState<BloodlineCardEventsResponse["events"]>([]);
+  const [events, setEvents] = useState<BloodlineCardEventsResponse["events"]>(
+    [],
+  );
   const [eventsLoading, setEventsLoading] = useState(false);
   const [missingCardRetryCount, setMissingCardRetryCount] = useState(0);
-  const [transferCandidates, setTransferCandidates] = useState<TransferUserItem[]>([]);
+  const [transferCandidates, setTransferCandidates] = useState<
+    TransferUserItem[]
+  >([]);
   const [transferSearchLoading, setTransferSearchLoading] = useState(false);
   const [showCelebrationModal, setShowCelebrationModal] = useState(false);
   const [celebrationCardName, setCelebrationCardName] = useState("");
@@ -117,7 +123,7 @@ export default function BloodlineCardDetailClient({ cardId }: BloodlineCardDetai
     const incoming = events.find(
       (event) =>
         (event.action === "LINE_ISSUED" || event.action === "LINE_TRANSFER") &&
-        event.toUser?.id === user.id
+        event.toUser?.id === user.id,
     );
 
     if (!incoming) return null;
@@ -137,7 +143,9 @@ export default function BloodlineCardDetailClient({ cardId }: BloodlineCardDetai
     const load = async () => {
       setEventsLoading(true);
       try {
-        const response = await fetch(`/api/bloodline-cards/${cardId}/events?limit=12`);
+        const response = await fetch(
+          `/api/bloodline-cards/${cardId}/events?limit=12`,
+        );
         const payload = (await response.json()) as BloodlineCardEventsResponse;
         if (!active) return;
         setEvents(payload.success ? payload.events : []);
@@ -154,7 +162,8 @@ export default function BloodlineCardDetailClient({ cardId }: BloodlineCardDetai
 
   useEffect(() => {
     const requested = searchParams?.get("action") as ActiveAction;
-    if (!requested || requested !== "transfer" && requested !== "issue") return;
+    if (!requested || (requested !== "transfer" && requested !== "issue"))
+      return;
     if (requested === "transfer" && !canTransfer) return;
     if (requested === "issue" && !canIssue) return;
     setActiveAction(requested);
@@ -175,11 +184,15 @@ export default function BloodlineCardDetailClient({ cardId }: BloodlineCardDetai
   const handleCloseCelebrationModal = () => {
     const resolvedPathname = pathname ?? "/";
     setShowCelebrationModal(false);
-    const nextSearchParams = new URLSearchParams(searchParams?.toString() || "");
+    const nextSearchParams = new URLSearchParams(
+      searchParams?.toString() || "",
+    );
     nextSearchParams.delete("celebration");
     nextSearchParams.delete("name");
     const nextQuery = nextSearchParams.toString();
-    router.replace(nextQuery ? `${resolvedPathname}?${nextQuery}` : resolvedPathname);
+    router.replace(
+      nextQuery ? `${resolvedPathname}?${nextQuery}` : resolvedPathname,
+    );
   };
 
   useEffect(() => {
@@ -241,7 +254,9 @@ export default function BloodlineCardDetailClient({ cardId }: BloodlineCardDetai
       await mutateCard();
     } catch (transferError) {
       setError(
-        transferError instanceof Error ? transferError.message : "카드 보내기 중 오류가 발생했습니다."
+        transferError instanceof Error
+          ? transferError.message
+          : "카드 보내기 중 오류가 발생했습니다.",
       );
     } finally {
       setTransferLoading(false);
@@ -263,7 +278,9 @@ export default function BloodlineCardDetailClient({ cardId }: BloodlineCardDetai
   };
 
   useEffect(() => {
-    const inputKeyword = String(transferDraft[card?.id || 0]?.toUserName || "").trim();
+    const inputKeyword = String(
+      transferDraft[card?.id || 0]?.toUserName || "",
+    ).trim();
     const selectedUserId = transferDraft[card?.id || 0]?.toUserId;
 
     if (activeAction !== "transfer" || !card) {
@@ -299,14 +316,15 @@ export default function BloodlineCardDetailClient({ cardId }: BloodlineCardDetai
       try {
         const response = await fetch(
           `/api/users/search?q=${encodeURIComponent(keyword)}&limit=8`,
-          { signal: controller.signal }
+          { signal: controller.signal },
         );
         const payload = (await response.json()) as {
           success: boolean;
           users?: TransferUserItem[];
         };
         if (!activeAction || !card) return;
-        if (keyword !== String(transferDraft[card.id]?.toUserName || "").trim()) return;
+        if (keyword !== String(transferDraft[card.id]?.toUserName || "").trim())
+          return;
         if (transferDraft[card.id]?.toUserId) return;
         if (response.ok && payload.success) {
           setTransferCandidates(payload.users || []);
@@ -329,7 +347,12 @@ export default function BloodlineCardDetailClient({ cardId }: BloodlineCardDetai
       }
       searchAbortRef.current?.abort();
     };
-  }, [activeAction, card?.id, transferDraft[card?.id || 0]?.toUserName, transferDraft[card?.id || 0]?.toUserId]);
+  }, [
+    activeAction,
+    card?.id,
+    transferDraft[card?.id || 0]?.toUserName,
+    transferDraft[card?.id || 0]?.toUserId,
+  ]);
 
   const handleIssueSubmit = async (event: FormEvent) => {
     event.preventDefault();
@@ -342,11 +365,14 @@ export default function BloodlineCardDetailClient({ cardId }: BloodlineCardDetai
     setIssueLoading(true);
 
     try {
-      const response = await fetch(`/api/bloodline-cards/${card.id}/issue-line`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ name: lineName }),
-      });
+      const response = await fetch(
+        `/api/bloodline-cards/${card.id}/issue-line`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ name: lineName }),
+        },
+      );
       const payload = (await response.json()) as BloodlineCardIssueLineResponse;
       if (!response.ok || !payload.success) {
         throw new Error(payload.error || "라인 만들기에 실패했습니다.");
@@ -358,7 +384,9 @@ export default function BloodlineCardDetailClient({ cardId }: BloodlineCardDetai
       await mutateCard();
     } catch (issueError) {
       setError(
-        issueError instanceof Error ? issueError.message : "라인 만들기 처리 중 오류가 발생했습니다."
+        issueError instanceof Error
+          ? issueError.message
+          : "라인 만들기 처리 중 오류가 발생했습니다.",
       );
     } finally {
       setIssueLoading(false);
@@ -389,7 +417,9 @@ export default function BloodlineCardDetailClient({ cardId }: BloodlineCardDetai
     return (
       <section className="app-page">
         <div className="mx-auto w-full max-w-[680px] rounded-xl border border-slate-200 bg-white p-5">
-          <h1 className="text-lg font-black text-slate-900">카드를 찾을 수 없습니다.</h1>
+          <h1 className="text-lg font-black text-slate-900">
+            카드를 찾을 수 없습니다.
+          </h1>
           <p className="mt-1 text-sm text-slate-600">
             카드 ID가 없거나 비활성화된 카드일 수 있습니다.
           </p>
@@ -409,21 +439,20 @@ export default function BloodlineCardDetailClient({ cardId }: BloodlineCardDetai
       <div className="mx-auto flex w-full max-w-[680px] flex-col gap-3">
         {showCelebrationModal ? (
           <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/55 px-4">
-            <div className="relative overflow-hidden rounded-3xl border-2 border-sky-300/90 bg-white/95 p-6 shadow-[0_28px_80px_rgba(2,132,199,0.35)] backdrop-blur">
-              <div className="pointer-events-none absolute -left-10 -top-16 h-40 w-40 rounded-full bg-cyan-200/50 blur-2xl" />
-              <div className="pointer-events-none absolute -right-8 -bottom-12 h-36 w-36 rounded-full bg-yellow-200/45 blur-2xl" />
-              <div className="absolute inset-x-0 top-0 flex justify-center">
-                <div className="mt-1 h-1.5 w-2/3 rounded-full bg-gradient-to-r from-yellow-300 via-sky-300 to-rose-300 animate-pulse" />
-              </div>
+            <div className="relative w-full max-w-sm rounded-lg border border-slate-200 bg-white p-5 shadow-xl">
               <div className="relative text-center">
-                <p className="text-sm font-black tracking-wide text-cyan-700">
-                  {celebrationCardName ? `"${celebrationCardName}"` : "혈통카드"}
+                <p className="text-sm font-bold text-slate-900">
+                  {celebrationCardName
+                    ? `"${celebrationCardName}"`
+                    : "혈통카드"}
                   가 완성됐습니다!
                 </p>
-                <p className="mt-2 text-base font-semibold text-slate-900">화면을 캡쳐해서 친구들에게 자랑하세요</p>
+                <p className="mt-2 text-sm leading-relaxed text-slate-500">
+                  화면을 캡쳐해서 친구들에게 공유해보세요.
+                </p>
                 <Button
                   type="button"
-                  className="mt-6 h-11 w-full bg-slate-900 text-sm font-black text-white hover:bg-slate-800"
+                  className="mt-5 h-11 w-full rounded-lg bg-slate-900 text-sm font-semibold text-white hover:bg-slate-800"
                   onClick={handleCloseCelebrationModal}
                 >
                   닫기
@@ -436,11 +465,11 @@ export default function BloodlineCardDetailClient({ cardId }: BloodlineCardDetai
           <div className={panelHeaderClass}>
             <Link
               href="/bloodline-management"
-              className="inline-flex h-8 items-center justify-center rounded-full border border-slate-200 bg-white px-3 text-xs font-medium text-slate-700 transition hover:bg-slate-50"
+              className="inline-flex h-8 items-center justify-center rounded-lg border border-slate-200 bg-white px-3 text-xs font-medium text-slate-700 transition hover:bg-slate-50"
             >
               목록으로
             </Link>
-            <span className="rounded-full bg-slate-100 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.12em] text-slate-700">
+            <span className="rounded-md bg-slate-100 px-2.5 py-1 text-[11px] font-semibold text-slate-700">
               {isBloodline ? "혈통카드" : "라인카드"}
             </span>
           </div>
@@ -456,7 +485,7 @@ export default function BloodlineCardDetailClient({ cardId }: BloodlineCardDetai
             <span className={chipClass}>ID #{card.id}</span>
           </div>
           {lineageTransferHint ? (
-            <p className="mt-2 inline-flex rounded-full bg-amber-50 px-3 py-1 text-xs text-amber-700">
+            <p className="mt-2 inline-flex rounded-md bg-amber-50 px-3 py-1 text-xs text-amber-700">
               {lineageTransferHint}
             </p>
           ) : null}
@@ -482,8 +511,7 @@ export default function BloodlineCardDetailClient({ cardId }: BloodlineCardDetai
           </div>
           <div className="grid gap-2">
             <p className={chipClass}>
-              제작자:
-              {" "}
+              제작자:{" "}
               <Link
                 href={`/profiles/${card.creator.id}`}
                 className="font-semibold text-slate-900 underline underline-offset-4"
@@ -492,8 +520,7 @@ export default function BloodlineCardDetailClient({ cardId }: BloodlineCardDetai
               </Link>
             </p>
             <p className={chipClass}>
-              현재 보유자:
-              {" "}
+              현재 보유자:{" "}
               <Link
                 href={`/profiles/${card.currentOwner.id}`}
                 className="font-semibold text-slate-900 underline underline-offset-4"
@@ -504,7 +531,8 @@ export default function BloodlineCardDetailClient({ cardId }: BloodlineCardDetai
             {card.cardType === "LINE" ? (
               <>
                 <div className={chipClass}>
-                  원본 혈통: {bloodlineSourceCard ? (
+                  원본 혈통:{" "}
+                  {bloodlineSourceCard ? (
                     <Link
                       href={`/bloodline-management/card/${bloodlineSourceCard.id}`}
                       className="font-semibold text-slate-900 underline underline-offset-4"
@@ -516,7 +544,8 @@ export default function BloodlineCardDetailClient({ cardId }: BloodlineCardDetai
                   )}
                 </div>
                 <div className={chipClass}>
-                  상위 라인: {parentLineCard ? (
+                  상위 라인:{" "}
+                  {parentLineCard ? (
                     <Link
                       href={`/bloodline-management/card/${parentLineCard.id}`}
                       className="font-semibold text-slate-900 underline underline-offset-4"
@@ -571,16 +600,20 @@ export default function BloodlineCardDetailClient({ cardId }: BloodlineCardDetai
                       placeholder="보내는 상대 닉네임(필수)"
                       className="h-11 rounded-lg"
                     />
-                    {(transferSearchLoading || transferCandidates.length > 0) ? (
+                    {transferSearchLoading || transferCandidates.length > 0 ? (
                       <div className="absolute left-0 right-0 z-20 mt-1 max-h-56 overflow-y-auto rounded-lg border border-slate-200 bg-white shadow-md">
                         {transferSearchLoading ? (
-                          <p className="px-3 py-2 text-sm text-slate-500">검색 중...</p>
+                          <p className="px-3 py-2 text-sm text-slate-500">
+                            검색 중...
+                          </p>
                         ) : transferCandidates.length ? (
                           transferCandidates.map((item) => (
                             <button
                               key={item.id}
                               type="button"
-                              onClick={() => handleTransferCandidateSelect(item)}
+                              onClick={() =>
+                                handleTransferCandidateSelect(item)
+                              }
                               className="w-full px-3 py-2 text-left text-sm text-slate-900 transition hover:bg-slate-50"
                             >
                               {item.name}
@@ -605,7 +638,11 @@ export default function BloodlineCardDetailClient({ cardId }: BloodlineCardDetai
                     className="h-11 rounded-lg"
                   />
                   <div className="grid gap-2">
-                    <Button type="submit" className={actionButtonClass} disabled={transferLoading}>
+                    <Button
+                      type="submit"
+                      className={actionButtonClass}
+                      disabled={transferLoading}
+                    >
                       {transferLoading ? "처리 중..." : "확인"}
                     </Button>
                     <Button
@@ -635,7 +672,11 @@ export default function BloodlineCardDetailClient({ cardId }: BloodlineCardDetai
                     className="h-11 rounded-lg"
                   />
                   <div className="grid gap-2">
-                    <Button type="submit" className={accentButtonClass} disabled={issueLoading}>
+                    <Button
+                      type="submit"
+                      className={accentButtonClass}
+                      disabled={issueLoading}
+                    >
                       {issueLoading ? "처리 중..." : "확인"}
                     </Button>
                     <Button
@@ -672,12 +713,13 @@ export default function BloodlineCardDetailClient({ cardId }: BloodlineCardDetai
               )}
             </div>
           ) : (
-            <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-600">
+            <div className="rounded-lg border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-600">
               <p className="font-medium text-slate-800">
                 이 카드는 현재 {card.currentOwner.name}님이 보유 중입니다.
               </p>
               <p className="mt-1 leading-relaxed">
-                상세 정보와 기록은 열람할 수 있고, 보내기나 라인 만들기는 보유자만 진행할 수 있습니다.
+                상세 정보와 기록은 열람할 수 있고, 보내기나 라인 만들기는
+                보유자만 진행할 수 있습니다.
               </p>
             </div>
           )}
@@ -698,20 +740,35 @@ export default function BloodlineCardDetailClient({ cardId }: BloodlineCardDetai
               {events.slice(0, 5).map((record) => (
                 <div
                   key={record.id}
-                  className={`rounded-lg border p-3 ${eventToneByAction[record.action] || "border-slate-200 bg-slate-50"} text-sm`}
+                  className={`rounded-lg border p-3 ${
+                    eventToneByAction[record.action] ||
+                    "border-slate-200 bg-slate-50"
+                  } text-sm`}
                 >
                   <div className="flex items-start justify-between gap-2">
-                    <p className="font-semibold text-slate-900">{actionLabel[record.action] || record.action}</p>
-                    <span className="text-[10px] font-semibold text-slate-700">{record.action}</span>
+                    <p className="font-semibold text-slate-900">
+                      {actionLabel[record.action] || record.action}
+                    </p>
+                    <span className="text-[10px] font-semibold text-slate-700">
+                      {record.action}
+                    </span>
                   </div>
                   <p className="mt-1 text-xs text-slate-700">
                     {record.actorUser?.name || "시스템"}
-                    {record.fromUser ? ` · ${record.fromUser.name} → ${record.toUser?.name || "시스템"}` : ""}
+                    {record.fromUser
+                      ? ` · ${record.fromUser.name} → ${
+                          record.toUser?.name || "시스템"
+                        }`
+                      : ""}
                   </p>
                   {record.note ? (
-                    <p className="mt-1 text-xs text-slate-500">메모: {record.note}</p>
+                    <p className="mt-1 text-xs text-slate-500">
+                      메모: {record.note}
+                    </p>
                   ) : null}
-                  <p className="mt-1 text-xs text-slate-500">{formatDate(record.createdAt)}</p>
+                  <p className="mt-1 text-xs text-slate-500">
+                    {formatDate(record.createdAt)}
+                  </p>
                 </div>
               ))}
             </div>

--- a/app/auth/login/LoginClient.tsx
+++ b/app/auth/login/LoginClient.tsx
@@ -115,7 +115,7 @@ const LoginClient = ({ shouldShowTestLogin }: LoginClientProps) => {
   const searchParams = useSearchParams();
   const [login] = useMutation<LoginResponseType>("/api/auth/login");
   const { data: foundingData } = useSWR<FoundingCountResponseType>(
-    "/api/breeder-programs/founding-count"
+    "/api/breeder-programs/founding-count",
   );
   const foundingRemaining = foundingData?.remaining ?? null;
   const isFoundingSoldOut =
@@ -123,13 +123,14 @@ const LoginClient = ({ shouldShowTestLogin }: LoginClientProps) => {
   const [testAccounts, setTestAccounts] = useState<TestAccountItem[]>([]);
   const [isLoadingTestAccounts, setIsLoadingTestAccounts] = useState(false);
   const [testLoginError, setTestLoginError] = useState("");
-  const [switchingTestUserId, setSwitchingTestUserId] = useState<number | null>(null);
+  const [switchingTestUserId, setSwitchingTestUserId] = useState<number | null>(
+    null,
+  );
   const [isReactNativeWebView, setIsReactNativeWebView] = useState(false);
   // 기본값은 노출(true). 추후 숨길 때 NEXT_PUBLIC_ENABLE_GOOGLE_LOGIN=false로 설정.
   const shouldShowGoogleLogin =
     process.env.NEXT_PUBLIC_ENABLE_GOOGLE_LOGIN !== "false";
-  const canShowGoogleLogin =
-    shouldShowGoogleLogin && !isReactNativeWebView;
+  const canShowGoogleLogin = shouldShowGoogleLogin && !isReactNativeWebView;
 
   /**카카오로그인 */
   const loginWithKakao = () => {
@@ -167,7 +168,7 @@ const LoginClient = ({ shouldShowTestLogin }: LoginClientProps) => {
         if (platform === "kakao") {
           script.setAttribute(
             "integrity",
-            "sha384-TiCUE00h649CAMonG018J2ujOgDKW/kVWlChEuu4jK2vxfAAD0eZxzCKakxg55G4"
+            "sha384-TiCUE00h649CAMonG018J2ujOgDKW/kVWlChEuu4jK2vxfAAD0eZxzCKakxg55G4",
           );
           script.setAttribute("crossorigin", "anonymous");
         }
@@ -179,7 +180,11 @@ const LoginClient = ({ shouldShowTestLogin }: LoginClientProps) => {
       }
       if (script) {
         // 이미 스크립트가 존재하는 경우(HMR/뒤로가기 등)도 SDK 초기화 상태를 맞춰준다.
-        if (platform === "kakao" && window.Kakao && !window.Kakao.isInitialized?.()) {
+        if (
+          platform === "kakao" &&
+          window.Kakao &&
+          !window.Kakao.isInitialized?.()
+        ) {
           window.Kakao.init(process.env.NEXT_PUBLIC_KAKAO_JAVASCRIPT_KEY);
         }
         return null;
@@ -190,7 +195,7 @@ const LoginClient = ({ shouldShowTestLogin }: LoginClientProps) => {
   useEffect(() => {
     loadScript(
       "https://t1.kakaocdn.net/kakao_js_sdk/2.7.2/kakao.min.js",
-      "kakao"
+      "kakao",
     );
   }, []);
 
@@ -214,14 +219,18 @@ const LoginClient = ({ shouldShowTestLogin }: LoginClientProps) => {
         const data = (await res.json()) as TestAccountListResponse;
         if (!mounted) return;
         if (!res.ok || !data.success) {
-          throw new Error(data.error || "테스트 계정 목록 조회에 실패했습니다.");
+          throw new Error(
+            data.error || "테스트 계정 목록 조회에 실패했습니다.",
+          );
         }
         setTestAccounts(data.users || []);
       } catch (error) {
         if (!mounted) return;
         setTestAccounts([]);
         setTestLoginError(
-          error instanceof Error ? error.message : "테스트 계정 목록 조회 중 오류가 발생했습니다."
+          error instanceof Error
+            ? error.message
+            : "테스트 계정 목록 조회 중 오류가 발생했습니다.",
         );
       } finally {
         if (mounted) {
@@ -306,7 +315,9 @@ const LoginClient = ({ shouldShowTestLogin }: LoginClientProps) => {
       void navigateAfterSessionReady(nextPath);
     } catch (error) {
       const message =
-        error instanceof Error ? error.message : "테스트 계정 전환 중 오류가 발생했습니다.";
+        error instanceof Error
+          ? error.message
+          : "테스트 계정 전환 중 오류가 발생했습니다.";
       setTestLoginError(message);
       alert(message);
     } finally {
@@ -315,132 +326,144 @@ const LoginClient = ({ shouldShowTestLogin }: LoginClientProps) => {
   };
 
   return (
-    <div className="min-h-screen w-full overflow-y-auto px-5 py-8 sm:py-10">
-      <div className="mx-auto flex w-full max-w-md flex-col">
-        <div className="mb-10 flex flex-col items-center text-center sm:mb-12">
-          <h1 className="title-10 text-Primary">브리디</h1>
-          <span className="body-3">애완동물 서비스는 브리디에서</span>
-          <span className="body-3">
-            생물인들과 소통하고 브리디에서 안전거래하세요
-          </span>
-        </div>
-        <div className="flex h-auto w-full flex-col items-center justify-center gap-y-4">
-        <button
-          onClick={() => loginWithKakao()}
-          className="button relative flex h-[54px] w-full items-center bg-[#FAE100] justify-center rounded-lg border border-Gray-300 px-7 py-[14px]"
-        >
-          <KakaoRound className="absolute left-7" width={26} height={26} />
-          {/* <KakaoLogin className="absolute left-7" width={26} height={26} /> */}
-          <span className="title-3">{"카카오로 계속하기"}</span>
-        </button>
-        {canShowGoogleLogin ? (
-          <button
-            onClick={() => loginWithGoogle()}
-            className="button relative flex h-[54px] w-full items-center justify-center rounded-lg border border-Gray-300 bg-white px-7 py-[14px]"
-          >
-            <GoogleRound className="absolute left-7" width={26} height={26} />
-            <span className="title-3">{"구글로 계속하기"}</span>
-          </button>
-        ) : !isReactNativeWebView ? (
-          <p className="mt-1 text-[11px] text-Gray-500">
-            현재는 카카오 로그인만 지원합니다.
+    <div className="min-h-screen w-full overflow-y-auto bg-slate-50 px-5 py-8 sm:py-10">
+      <div className="mx-auto flex w-full max-w-sm flex-col">
+        <div className="mb-8">
+          <p className="text-[13px] font-semibold text-primary">Bredy</p>
+          <h1 className="mt-2 text-[30px] font-bold leading-tight tracking-[-0.02em] text-slate-950">
+            브리디 로그인
+          </h1>
+          <p className="mt-2 text-sm leading-relaxed text-slate-500">
+            생물인들과 소통하고 안전하게 거래하세요.
           </p>
-        ) : null}
-        {shouldShowTestLogin ? (
-          <div className="w-full rounded-lg border border-Gray-200 bg-Gray-50 p-3">
-            <p className="text-[11px] text-Gray-500">테스트 로그인 (개발/테스트 환경 전용)</p>
-            {isLoadingTestAccounts ? (
-              <p className="mt-2 text-[11px] text-Gray-500">테스트 계정 목록 불러오는 중...</p>
-            ) : null}
-            {testLoginError ? <p className="mt-2 text-[11px] text-rose-500">{testLoginError}</p> : null}
-            {!isLoadingTestAccounts && !testAccounts.length ? (
-              <p className="mt-2 text-[11px] text-Gray-500">
-                사용 가능한 테스트 계정이 없습니다.
-              </p>
-            ) : (
-              <div className="mt-2 max-h-64 space-y-1 overflow-y-auto pr-1">
-                {testAccounts.map((account) => (
-                  <button
-                    key={account.id}
-                    type="button"
-                    onClick={() => loginAsTestUser(account.id)}
-                    disabled={switchingTestUserId === account.id}
-                    className="button relative flex h-10 w-full items-center justify-between rounded-md border border-Gray-300 bg-white px-3 text-left"
-                  >
-                    <span className="text-xs text-Gray-700 truncate">{account.name}</span>
-                    <span className="text-[11px] text-Gray-500">
-                      {switchingTestUserId === account.id
-                        ? "전환 중..."
-                        : account.provider}
-                    </span>
-                  </button>
-                ))}
-              </div>
-            )}
-          </div>
-        ) : null}
-        <Link
-          href={"/"}
-          className="button relative flex h-[54px] w-full items-center justify-center rounded-lg border border-Gray-300 px-7 py-[14px]"
-        >
-          <span className="title-3">{"서비스 둘러보기"}</span>
-        </Link>
-        <Link
-          href="/content/breeder-program"
-          className="w-full rounded-2xl border border-amber-200 bg-gradient-to-br from-amber-50 via-white to-slate-50 p-4 text-left shadow-sm transition-transform hover:-translate-y-0.5"
-        >
-          <div className="flex items-start justify-between gap-3">
-            <div>
-              <p className="text-[11px] font-black uppercase tracking-[0.18em] text-amber-700">
-                Founding Breeder 100
-              </p>
-              <h2 className="mt-1 text-lg font-bold text-slate-900">
-                {isFoundingSoldOut
-                  ? "창립 브리더 100인 마감"
-                  : "창립 브리더 100인 한정"}
-              </h2>
-              <p className="mt-1 text-sm leading-relaxed text-slate-600">
-                {isFoundingSoldOut
-                  ? "창립 브리더 100인이 모두 선정되었습니다. 프로그램 소개를 확인해보세요."
-                  : "브리디를 처음 시작한 100명은 평생 경매 수수료 무료, 전용 프레임과 전용 뱃지 혜택을 받습니다."}
-              </p>
-            </div>
-            <span className="shrink-0 rounded-full bg-slate-900 px-2.5 py-1 text-[11px] font-semibold text-white">
-              자세히
-            </span>
-          </div>
-          <div className="mt-3 flex flex-wrap gap-2">
-            {foundingRemaining !== null && !isFoundingSoldOut ? (
-              <span className="rounded-full border border-rose-200 bg-rose-50 px-2.5 py-1 text-[11px] font-semibold text-rose-700">
-                잔여 {foundingRemaining}석
-              </span>
-            ) : null}
-            <span className="rounded-full border border-amber-200 bg-amber-50 px-2.5 py-1 text-[11px] font-semibold text-amber-800">
-              평생 경매 수수료 무료
-            </span>
-            <span className="rounded-full border border-slate-200 bg-white px-2.5 py-1 text-[11px] font-semibold text-slate-700">
-              전용 프레임
-            </span>
-            <span className="rounded-full border border-slate-200 bg-white px-2.5 py-1 text-[11px] font-semibold text-slate-700">
-              전용 뱃지
-            </span>
-          </div>
-        </Link>
-        {/* <div
-          onClick={() => loginWithApple()}
-          className="relative flex h-[54px] w-full cursor-pointer items-center justify-center rounded-lg border border-Gray-300 px-7 py-[14px]"
-        >
-          <AppleSquare className="absolute left-7" width={26} height={26} />
-          <span className="title-3">{"애플로 회원가입"}</span>
-        </div> */}
         </div>
-        <div className="mb-2 mt-10 w-full border-t-[1px] border-Gray-300" />
-        <div className="body-1 text-Gray-400">
+
+        <div className="flex h-auto w-full flex-col gap-3">
+          <button
+            type="button"
+            onClick={() => loginWithKakao()}
+            className="button relative flex h-[52px] w-full items-center justify-center rounded-lg border border-[#E2CD00] bg-[#FEE500] px-6 text-[#191919] transition-colors hover:bg-[#FADA0A]"
+          >
+            <KakaoRound className="absolute left-5" width={24} height={24} />
+            <span className="text-sm font-semibold">카카오로 계속하기</span>
+          </button>
+
+          {canShowGoogleLogin ? (
+            <button
+              type="button"
+              onClick={() => loginWithGoogle()}
+              className="button relative flex h-[52px] w-full items-center justify-center rounded-lg border border-slate-200 bg-white px-6 text-slate-900 transition-colors hover:bg-slate-50"
+            >
+              <GoogleRound className="absolute left-5" width={24} height={24} />
+              <span className="text-sm font-semibold">구글로 계속하기</span>
+            </button>
+          ) : !isReactNativeWebView ? (
+            <p className="text-[12px] text-slate-500">
+              현재는 카카오 로그인만 지원합니다.
+            </p>
+          ) : null}
+
+          {shouldShowTestLogin ? (
+            <div className="w-full rounded-lg border border-slate-200 bg-white p-3">
+              <p className="text-[11px] font-semibold text-slate-500">
+                테스트 로그인 (개발/테스트 환경 전용)
+              </p>
+              {isLoadingTestAccounts ? (
+                <p className="mt-2 text-[11px] text-slate-500">
+                  테스트 계정 목록 불러오는 중...
+                </p>
+              ) : null}
+              {testLoginError ? (
+                <p className="mt-2 text-[11px] text-rose-600">
+                  {testLoginError}
+                </p>
+              ) : null}
+              {!isLoadingTestAccounts && !testAccounts.length ? (
+                <p className="mt-2 text-[11px] text-slate-500">
+                  사용 가능한 테스트 계정이 없습니다.
+                </p>
+              ) : (
+                <div className="mt-2 max-h-64 space-y-1 overflow-y-auto pr-1">
+                  {testAccounts.map((account) => (
+                    <button
+                      key={account.id}
+                      type="button"
+                      onClick={() => loginAsTestUser(account.id)}
+                      disabled={switchingTestUserId === account.id}
+                      className="button relative flex h-10 w-full items-center justify-between rounded-md border border-slate-200 bg-slate-50 px-3 text-left transition-colors hover:bg-white disabled:opacity-60"
+                    >
+                      <span className="truncate text-xs text-slate-700">
+                        {account.name}
+                      </span>
+                      <span className="text-[11px] text-slate-500">
+                        {switchingTestUserId === account.id
+                          ? "전환 중..."
+                          : account.provider}
+                      </span>
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+          ) : null}
+
+          <Link
+            href={"/"}
+            className="button relative flex h-[52px] w-full items-center justify-center rounded-lg border border-slate-200 bg-white px-6 text-sm font-semibold text-slate-700 transition-colors hover:bg-slate-50"
+          >
+            서비스 둘러보기
+          </Link>
+
+          <Link
+            href="/content/breeder-program"
+            className="w-full rounded-lg border border-slate-200 bg-white p-4 text-left transition-colors hover:border-slate-300 hover:bg-slate-50"
+          >
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <p className="text-[11px] font-semibold text-primary">
+                  Founding Breeder 100
+                </p>
+                <h2 className="mt-1 text-base font-bold text-slate-950">
+                  {isFoundingSoldOut
+                    ? "창립 브리더 100인 마감"
+                    : "창립 브리더 100인 한정"}
+                </h2>
+                <p className="mt-1 text-[13px] leading-relaxed text-slate-500">
+                  {isFoundingSoldOut
+                    ? "창립 브리더 프로그램 소개를 확인해보세요."
+                    : "초기 100명에게 평생 경매 수수료 무료와 전용 표시 혜택을 제공합니다."}
+                </p>
+              </div>
+              <span className="shrink-0 rounded-md bg-slate-900 px-2 py-1 text-[11px] font-semibold text-white">
+                보기
+              </span>
+            </div>
+            <div className="mt-3 flex flex-wrap gap-1.5">
+              {foundingRemaining !== null && !isFoundingSoldOut ? (
+                <span className="rounded-md border border-rose-200 bg-rose-50 px-2 py-1 text-[11px] font-semibold text-rose-700">
+                  잔여 {foundingRemaining}석
+                </span>
+              ) : null}
+              <span className="rounded-md border border-slate-200 bg-slate-50 px-2 py-1 text-[11px] font-semibold text-slate-600">
+                수수료 무료
+              </span>
+              <span className="rounded-md border border-slate-200 bg-slate-50 px-2 py-1 text-[11px] font-semibold text-slate-600">
+                전용 프레임
+              </span>
+              <span className="rounded-md border border-slate-200 bg-slate-50 px-2 py-1 text-[11px] font-semibold text-slate-600">
+                전용 뱃지
+              </span>
+            </div>
+          </Link>
+        </div>
+
+        <div className="mb-2 mt-8 w-full border-t border-slate-200" />
+        <div className="text-[11px] leading-relaxed text-slate-400">
           <span>
             서비스 이용시 브리디의{" "}
             <Link
               target="_blank"
-              className="text-Primary"
+              className="font-semibold text-primary"
               href={TERMS_OF_SERVICE_URL}
             >
               이용약관
@@ -448,7 +471,7 @@ const LoginClient = ({ shouldShowTestLogin }: LoginClientProps) => {
             및{" "}
             <Link
               target="_blank"
-              className="text-Primary"
+              className="font-semibold text-primary"
               href={PRIVACY_POLICY_URL}
             >
               개인정보처리동의서

--- a/components/features/bloodline/BloodlineVisualCard.tsx
+++ b/components/features/bloodline/BloodlineVisualCard.tsx
@@ -24,53 +24,48 @@ const CARD_VARIANTS: Record<
   BloodlineVisualCardVariant,
   {
     cardClass: string;
-    glowClass: string;
-    decoClass: string;
-    imageOverlayClass: string;
-    titleClass: string;
+    imageFrameClass: string;
+    placeholderClass: string;
+    badgeClass: string;
+    labelClass: string;
     nameClass: string;
-    markClass: string;
+    metaClass: string;
+    subtleClass: string;
     serialClass: string;
   }
 > = {
   noir: {
-    cardClass:
-      "bg-slate-950 text-white border-slate-900/20 shadow-[0_18px_36px_rgba(15,23,42,0.28)]",
-    glowClass:
-      "bg-[radial-gradient(circle_at_24%_22%,rgba(255,255,255,0.22),transparent_30%),radial-gradient(circle_at_80%_2%,rgba(245,137,66,0.24),transparent_33%),linear-gradient(125deg,rgba(255,255,255,0.14),rgba(255,255,255,0)_50%)]",
-    decoClass: "rounded-full border border-white/10",
-    imageOverlayClass: "bg-slate-900/45",
-    titleClass: "text-white/75 uppercase tracking-[0.16em]",
+    cardClass: "border-slate-800 bg-slate-950 text-white",
+    imageFrameClass: "border-slate-800 bg-slate-900",
+    placeholderClass: "bg-slate-900 text-slate-500",
+    badgeClass: "border-white/20 bg-white/10 text-white/80",
+    labelClass: "text-white/50",
     nameClass: "text-white",
-    markClass: "text-white/85 border-white/30 bg-white/10",
-    serialClass:
-      "text-white border-white/35 bg-slate-900/78 shadow-[inset_0_0_0_1px_rgba(255,255,255,0.08),0_8px_24px_rgba(15,23,42,0.45)]",
+    metaClass: "border-white/10 bg-white/[0.04] text-white",
+    subtleClass: "text-white/60",
+    serialClass: "border-white/10 bg-white/[0.05] text-white",
   },
   clean: {
-    cardClass:
-      "bg-white text-slate-900 border-slate-200/80 shadow-[0_12px_26px_rgba(15,23,42,0.12)]",
-    glowClass:
-      "bg-[radial-gradient(circle_at_88%_4%,rgba(245,137,66,0.16),transparent_42%)]",
-    decoClass: "rounded-full border border-slate-200/85",
-    imageOverlayClass: "bg-slate-50/45",
-    titleClass: "text-slate-700 uppercase tracking-[0.18em]",
-    nameClass: "text-slate-900",
-    markClass: "text-slate-700 border-slate-300 bg-white/75",
-    serialClass:
-      "text-slate-900 border-slate-200/75 bg-white/95 shadow-[inset_0_0_0_1px_rgba(15,23,42,0.05),0_6px_18px_rgba(15,23,42,0.16)]",
+    cardClass: "border-slate-200 bg-white text-slate-900",
+    imageFrameClass: "border-slate-200 bg-slate-100",
+    placeholderClass: "bg-slate-100 text-slate-400",
+    badgeClass: "border-slate-200 bg-white/90 text-slate-700",
+    labelClass: "text-slate-400",
+    nameClass: "text-slate-950",
+    metaClass: "border-slate-200 bg-slate-50 text-slate-900",
+    subtleClass: "text-slate-500",
+    serialClass: "border-slate-200 bg-white text-slate-900",
   },
   editorial: {
-    cardClass:
-      "bg-gradient-to-br from-slate-50 via-white to-slate-100 text-slate-900 border-slate-300/70 shadow-[0_10px_26px_rgba(15,23,42,0.15)]",
-    glowClass:
-      "bg-[linear-gradient(145deg,rgba(15,23,42,0.06),rgba(245,137,66,0.12),rgba(15,23,42,0)_70%)]",
-    decoClass: "rounded-full border border-slate-300/65",
-    imageOverlayClass: "bg-slate-900/38",
-    titleClass: "text-slate-700 uppercase tracking-[0.18em]",
-    nameClass: "text-slate-900",
-    markClass: "text-slate-700 border-slate-300 bg-white/80",
-    serialClass:
-      "text-slate-900 border-slate-400/80 bg-slate-100/90 shadow-[inset_0_0_0_1px_rgba(15,23,42,0.08),0_6px_18px_rgba(15,23,42,0.16)]",
+    cardClass: "border-zinc-200 bg-zinc-50 text-slate-900",
+    imageFrameClass: "border-zinc-200 bg-zinc-100",
+    placeholderClass: "bg-zinc-100 text-zinc-400",
+    badgeClass: "border-zinc-200 bg-zinc-50/90 text-zinc-700",
+    labelClass: "text-zinc-500",
+    nameClass: "text-slate-950",
+    metaClass: "border-zinc-200 bg-white text-slate-900",
+    subtleClass: "text-zinc-600",
+    serialClass: "border-zinc-300 bg-zinc-50 text-slate-900",
   },
 };
 
@@ -103,15 +98,9 @@ export function BloodlineVisualCard({
 }: BloodlineVisualCardProps) {
   const serialText = makeFallbackCardSerial(cardId, name);
   const activeVariant = CARD_VARIANTS[variant];
-  const metaCardClass =
-    variant === "noir"
-      ? "border-white/10 bg-black/10 text-white"
-      : "border-slate-200/80 bg-white/80 text-slate-900";
-  const metaLabelClass = variant === "noir" ? "text-white/65" : "text-slate-500";
-  const metaDescriptionClass = variant === "noir" ? "text-white/72" : "text-slate-600";
   const aspectClass = compact
-    ? "aspect-[4/5] min-h-[188px] p-3"
-    : "aspect-[4/5] min-h-[320px] p-4";
+    ? "aspect-[4/5] min-h-[188px]"
+    : "aspect-[4/5] min-h-[320px]";
   const resolvedImageUrl = imageUrl
     ? imageUrl
     : image
@@ -119,67 +108,98 @@ export function BloodlineVisualCard({
     : "";
 
   return (
-    <article className={`relative ${compact ? "w-full" : "mx-auto w-full max-w-[360px]"}`}>
+    <article
+      className={`relative ${
+        compact ? "w-full" : "mx-auto w-full max-w-[360px]"
+      }`}
+    >
       <div
-        className={`relative ${aspectClass} overflow-hidden rounded-[22px] border ${activeVariant.cardClass}`}
+        className={`relative ${aspectClass} overflow-hidden rounded-xl border shadow-sm ${activeVariant.cardClass}`}
       >
-        {resolvedImageUrl ? (
-          <div className="pointer-events-none absolute inset-0">
-            <Image
-              src={resolvedImageUrl}
-              alt=""
-              fill
-              sizes={compact ? "240px" : "360px"}
-              className="object-cover object-center opacity-75"
-              unoptimized
-            />
-            <div className={`absolute inset-0 ${activeVariant.imageOverlayClass}`} />
-          </div>
-        ) : (
-          <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(255,255,255,0.14),transparent_32%),radial-gradient(circle_at_82%_18%,rgba(245,137,66,0.18),transparent_28%),linear-gradient(145deg,rgba(255,255,255,0.06),rgba(15,23,42,0)_48%)]" />
-        )}
-        <div className={`pointer-events-none absolute inset-0 ${activeVariant.glowClass}`} />
-        <div className={`pointer-events-none absolute -left-8 -top-7 h-20 w-20 ${activeVariant.decoClass}`} />
-        <div className={`pointer-events-none absolute -right-8 top-8 h-24 w-24 ${activeVariant.decoClass}`} />
-        <div className="pointer-events-none absolute inset-x-4 top-[56%] h-px bg-white/10" />
-
-        <div className="relative z-10 flex h-full flex-col justify-between">
-          <span
-            className={`inline-flex w-fit items-center rounded-full border px-2 py-1 text-[10px] font-semibold tracking-[0.18em] ${activeVariant.markClass}`}
+        <div className="flex h-full flex-col">
+          <div
+            className={`relative h-[52%] overflow-hidden border-b ${activeVariant.imageFrameClass}`}
           >
-            BLOODLINE SERIES
-          </span>
-          <div className="space-y-3">
-            <p
-              className={`${compact ? "text-[11px]" : "text-[13px]"} font-semibold tracking-[0.16em] ${activeVariant.titleClass}`}
+            {resolvedImageUrl ? (
+              <Image
+                src={resolvedImageUrl}
+                alt=""
+                fill
+                sizes={compact ? "240px" : "360px"}
+                className="object-cover object-center"
+                unoptimized
+              />
+            ) : (
+              <div
+                className={`flex h-full w-full items-center justify-center px-3 py-2 ${activeVariant.placeholderClass}`}
+              >
+                <div className="text-center">
+                  <p className="text-[10px] font-semibold tracking-[0.14em]">
+                    BREDY
+                  </p>
+                  <p className="mt-1 text-[11px] font-semibold">BLOODLINE</p>
+                </div>
+              </div>
+            )}
+            <span
+              className={`absolute left-2.5 top-2.5 inline-flex h-6 items-center rounded-md border px-2 text-[10px] font-semibold ${activeVariant.badgeClass}`}
             >
-              BLOODLINE CARD
-            </p>
-            <p
-              className={`mt-1 ${compact ? "text-[21px]" : "text-[26px]"} line-clamp-2 font-semibold leading-[1.06] tracking-[-0.03em] ${activeVariant.nameClass}`}
-              title={name}
-            >
-              {name}
-            </p>
-            <div className={`mt-3 max-w-[88%] rounded-2xl border px-3 py-2 backdrop-blur-[6px] ${metaCardClass}`}>
-              <p className={`text-[10px] font-semibold uppercase tracking-[0.18em] ${metaLabelClass}`}>
-                Owner
+              {cardId ? `#${cardId}` : "DRAFT"}
+            </span>
+          </div>
+
+          <div
+            className={`${
+              compact ? "p-3" : "p-4"
+            } flex flex-1 flex-col justify-between`}
+          >
+            <div>
+              <p
+                className={`${
+                  compact ? "text-[10px]" : "text-[11px]"
+                } font-semibold ${activeVariant.labelClass}`}
+              >
+                혈통카드
               </p>
-              <p className="mt-1 text-sm font-semibold">{ownerName}</p>
-              <p className={`mt-1 line-clamp-2 text-[11px] leading-relaxed ${metaDescriptionClass}`}>
-                {subtitle || "브리더가 만든 혈통카드"}
+              <p
+                className={`mt-1 ${
+                  compact ? "text-[20px]" : "text-[25px]"
+                } line-clamp-2 font-bold leading-[1.08] tracking-[-0.02em] ${
+                  activeVariant.nameClass
+                }`}
+                title={name}
+              >
+                {name}
               </p>
             </div>
-            <div className="flex justify-start">
+
+            <div className="mt-3 grid gap-2">
               <div
-                className={`relative inline-flex max-w-full flex-col rounded-xl border px-3 py-2 ${activeVariant.serialClass}`}
+                className={`rounded-lg border px-3 py-2 ${activeVariant.metaClass}`}
               >
-                <span className="absolute inset-x-0 top-[4px] h-px bg-current/22" />
-                <span className="absolute inset-x-0 bottom-[4px] h-px bg-current/8" />
-                <p className="text-[8px] leading-none tracking-[0.28em] text-current/65">
-                  BLOODLINE CODE
+                <p
+                  className={`text-[10px] font-semibold ${activeVariant.labelClass}`}
+                >
+                  보유자
                 </p>
-                <p className="mt-1 text-[11px] leading-none tracking-[0.18em] font-semibold uppercase font-mono text-current">
+                <p className="mt-0.5 truncate text-sm font-semibold">
+                  {ownerName}
+                </p>
+                <p
+                  className={`mt-1 line-clamp-2 text-[11px] leading-relaxed ${activeVariant.subtleClass}`}
+                >
+                  {subtitle || "브리더가 만든 혈통카드"}
+                </p>
+              </div>
+              <div
+                className={`inline-flex max-w-full flex-col rounded-lg border px-3 py-2 ${activeVariant.serialClass}`}
+              >
+                <p
+                  className={`text-[9px] leading-none ${activeVariant.labelClass}`}
+                >
+                  카드 코드
+                </p>
+                <p className="mt-1 text-[11px] font-semibold leading-none tracking-[0.12em] text-current">
                   {serialText}
                 </p>
               </div>


### PR DESCRIPTION
### 개요

경매, 로그인, 혈통카드 화면의 과한 그라데이션/큰 radius/강한 shadow/pill 스타일을 줄이고, 기존 앱 톤과 맞는 담백한 UI로 정리했습니다.

### 변경 유형

- [ ] 버그 수정
- [ ] 새로운 기능 추가
- [ ] 기존 기능 수정
- [x] 스타일 수정
- [ ] 기타(문서 수정, 리팩토링 등)

### 주요 변경사항

- 로그인 화면을 단정한 인증 화면 형태로 재정리
- 경매 목록/상세/등록 화면의 CTA, 필터, 카드, 모달 스타일 통일
- 경매 목록 API 실패 시 스켈레톤 고착 대신 오류/재시도 상태 표시
- 혈통카드 비주얼 컴포넌트를 실물 카드형 레이아웃으로 정리
- 혈통관리/혈통카드 생성 주변 패널의 border radius, border, shadow 톤 통일

---

### 관련 태스크 / 이슈

- 별도 이슈 없음

### 스크린샷

- 로컬 브라우저에서 `/auth/login`, `/auctions`, `/bloodline-cards/create`, `/auctions/create` 렌더링 확인

### 테스트

- `npm run verify:ci` 통과
- `npm run lint` 통과

### 리스크 / 메모

- 기존 `BloodlineCardCreateClient.tsx`의 `<img>` 사용 lint warning 1개는 남아 있습니다.
- 변경 파일 내 기존 `LoginClient.tsx` 카카오 SDK 로딩 처리 `console.log` 2개는 이번 PR에서 수정하지 않았습니다.
- 로컬 브라우저 확인 중 DB tenant host 해석 실패로 일부 API가 500을 반환했고, 경매 목록 실패 상태 노출을 추가로 확인했습니다.
