### PR TITLE
style: 홈 화면과 브리더 프로그램 UI 개선

### DIFF
--- a/app/(web)/(main)/MainClient.tsx
+++ b/app/(web)/(main)/MainClient.tsx
@@ -64,42 +64,9 @@ const formatRankDelta = (rankDelta: number) => {
   return "유지";
 };
 
-const getBannerTone = (bgClass: string) => {
-  if (bgClass.includes("orange") || bgClass.includes("amber")) {
-    return {
-      card: "border-orange-100 bg-orange-50/45",
-      chip: "border-orange-100 bg-white text-orange-700",
-      visual: "border-orange-100 bg-orange-100 text-orange-700",
-    };
-  }
 
-  if (bgClass.includes("sky") || bgClass.includes("cyan")) {
-    return {
-      card: "border-blue-100 bg-blue-50/45",
-      chip: "border-blue-100 bg-white text-blue-700",
-      visual: "border-blue-100 bg-blue-100 text-blue-700",
-    };
-  }
-
-  if (bgClass.includes("emerald") || bgClass.includes("teal")) {
-    return {
-      card: "border-emerald-100 bg-emerald-50/45",
-      chip: "border-emerald-100 bg-white text-emerald-700",
-      visual: "border-emerald-100 bg-emerald-100 text-emerald-700",
-    };
-  }
-
-  return {
-    card: "border-slate-200 bg-white",
-    chip: "border-slate-200 bg-slate-50 text-slate-700",
-    visual: "border-slate-200 bg-slate-100 text-slate-700",
-  };
-};
-
-const toRankingHref = (
-  tab: "breeders" | "auctions" | "bloodlines" | "community",
-  period: "weekly" | "all",
-) => `/ranking?tab=${tab}&period=${period}`;
+const toRankingHref = (tab: "breeders" | "auctions" | "bloodlines" | "community", period: "weekly" | "all") =>
+  `/ranking?tab=${tab}&period=${period}`;
 
 const MainClient = ({
   initialHomeFeed,
@@ -122,7 +89,7 @@ const MainClient = ({
 
   const getKey = (
     pageIndex: number,
-    previousPageData: ProductsResponse | null,
+    previousPageData: ProductsResponse | null
   ) => {
     if (previousPageData && !previousPageData.products.length) return null;
     const categoryParam =
@@ -146,7 +113,7 @@ const MainClient = ({
       revalidateOnFocus: false,
       revalidateOnMount: false,
       revalidateIfStale: false,
-    },
+    }
   );
   const banners = initialBanners;
 
@@ -286,18 +253,12 @@ const MainClient = ({
   };
 
   const loadedProductCount =
-    data?.reduce(
-      (count, pageData) => count + (pageData?.products?.length ?? 0),
-      0,
-    ) ?? 0;
+    data?.reduce((count, pageData) => count + (pageData?.products?.length ?? 0), 0) ?? 0;
   const heroBreederPeriod = homeFeedData?.heroBreederMode ?? "weekly";
-  const auctionPeriod =
-    homeFeedData?.topAuctionsMode === "all" ? "all" : "weekly";
+  const auctionPeriod = homeFeedData?.topAuctionsMode === "all" ? "all" : "weekly";
   const bloodlinePeriod = homeFeedData?.topBloodlinesMode ?? "weekly";
-  const communityPeriod =
-    homeFeedData?.trendingPostsMode === "all" ? "all" : "weekly";
-  const bloodlineSubtitle =
-    "가장 많은 사용자가 보유한 혈통카드를 기준으로 집계한 랭킹";
+  const communityPeriod = homeFeedData?.trendingPostsMode === "all" ? "all" : "weekly";
+  const bloodlineSubtitle = "가장 많은 사용자가 보유한 혈통카드를 기준으로 집계한 랭킹";
   const communitySubtitle = "좋아요와 댓글 반응이 높은 커뮤니티 글";
 
   return (
@@ -307,11 +268,9 @@ const MainClient = ({
         <div
           ref={bannerRef}
           onScroll={handleBannerScroll}
-          className="app-rail flex gap-3 px-4 py-1"
+          className="app-rail flex gap-0"
         >
-          {banners.map((banner) => {
-            const tone = getBannerTone(banner.bgClass);
-            return (
+            {banners.map((banner) => (
               <Link
                 key={banner.id}
                 href={banner.href}
@@ -324,64 +283,32 @@ const MainClient = ({
                   })
                 }
                 className={cn(
-                  "snap-start flex min-h-[128px] w-[calc(100%-28px)] shrink-0 items-stretch justify-between gap-4 overflow-hidden rounded-xl border p-4 text-slate-950 shadow-none transition-colors",
-                  "sm:w-[calc(100%-40px)]",
-                  tone.card,
+                  "snap-start shrink-0 w-full app-card-interactive rounded-none border-0 shadow-none px-5 py-5 text-white bg-gradient-to-r relative overflow-hidden from-emerald-500 to-teal-500",
+                  banner.bgClass
                 )}
               >
-                <div className="min-w-0 flex-1 self-center">
-                  <span
-                    className={cn(
-                      "inline-flex h-6 items-center rounded-full border px-2 text-[11px] font-semibold",
-                      tone.chip,
-                    )}
-                  >
-                    Bredy
-                  </span>
-                  <h2 className="mt-2 line-clamp-1 text-[18px] font-bold text-slate-950">
-                    {banner.title}
-                  </h2>
-                  <p className="mt-1 line-clamp-2 text-[13px] font-medium text-slate-500">
-                    {banner.description}
-                  </p>
-                  <span className="mt-3 inline-flex text-[13px] font-semibold text-slate-900">
-                    자세히 보기 ›
-                  </span>
-                </div>
-                <div
-                  className={cn(
-                    "relative flex h-24 w-24 shrink-0 items-center justify-center overflow-hidden rounded-lg border",
-                    tone.visual,
-                  )}
-                >
-                  {banner.image ? (
-                    <Image
-                      src={makeImageUrl(banner.image, "public")}
-                      alt=""
-                      width={96}
-                      height={96}
-                      className="h-full w-full object-cover"
-                    />
-                  ) : (
-                    <span className="text-xl font-black">B</span>
-                  )}
-                </div>
+                <span className="app-kicker text-white/75 relative z-10">Bredy</span>
+                <h2 className="mt-2 app-title-lg text-white relative z-10">{banner.title}</h2>
+                <p className="mt-1 app-body-sm text-white/90 line-clamp-2 relative z-10">
+                  {banner.description}
+                </p>
+                <span className="mt-4 inline-flex h-7 items-center rounded-full bg-white/20 px-2.5 text-[11px] font-semibold text-white/95 backdrop-blur-sm relative z-10">
+                  자세히 보기
+                </span>
+                <div className="pointer-events-none absolute -right-8 -top-10 h-28 w-28 rounded-full bg-white/12" />
               </Link>
-            );
-          })}
+            ))}
+
         </div>
-        <div className="mt-2 flex items-center gap-1 px-5">
+        <div className="mt-3 flex items-center justify-center gap-1.5">
           {banners.map((banner, index: number) => (
             <button
               key={banner.id}
               onClick={() => scrollToBanner(index)}
               aria-label={`${index + 1}번 배너로 이동`}
-              aria-current={activeBannerIndex === index ? "true" : undefined}
               className={cn(
-                "h-1 rounded-full transition-all",
-                activeBannerIndex === index
-                  ? "w-5 bg-slate-900"
-                  : "w-2 bg-slate-300",
+                "h-1.5 rounded-full transition-all",
+                activeBannerIndex === index ? "w-6 bg-slate-900" : "w-2 bg-slate-300"
               )}
             />
           ))}
@@ -398,9 +325,7 @@ const MainClient = ({
                 <span className="inline-flex items-center rounded-full bg-white/25 px-2 py-0.5 text-[9px] font-bold uppercase tracking-widest">
                   이벤트
                 </span>
-                <h3 className="text-sm font-black leading-tight">
-                  혈통카드 공유 챌린지
-                </h3>
+                <h3 className="text-sm font-black leading-tight">혈통카드 공유 챌린지</h3>
               </div>
               <p className="mt-1 text-[11px] leading-snug text-white/90">
                 내 혈통카드를 공유하고 특별 배지를 받으세요!
@@ -446,10 +371,7 @@ const MainClient = ({
                   <div className="h-11 w-11 overflow-hidden rounded-full bg-slate-100 ring-2 ring-amber-400/60">
                     {homeFeedData.heroBreeder.user.avatar ? (
                       <Image
-                        src={makeImageUrl(
-                          homeFeedData.heroBreeder.user.avatar,
-                          "avatar",
-                        )}
+                        src={makeImageUrl(homeFeedData.heroBreeder.user.avatar, "avatar")}
                         alt={homeFeedData.heroBreeder.user.name}
                         width={44}
                         height={44}
@@ -470,20 +392,14 @@ const MainClient = ({
                     <h3 className="truncate text-sm font-bold text-slate-900">
                       {homeFeedData.heroBreeder.user.name}
                     </h3>
-                    {(homeFeedData.heroBreeder.badges || [])
-                      .slice(0, 1)
-                      .map((badge) => (
-                        <span
-                          key={badge.id}
-                          className="shrink-0 rounded bg-amber-50 px-1.5 py-0.5 text-[9px] font-semibold text-amber-600"
-                        >
-                          {badge.label}
-                        </span>
-                      ))}
+                    {(homeFeedData.heroBreeder.badges || []).slice(0, 1).map((badge) => (
+                      <span key={badge.id} className="shrink-0 rounded bg-amber-50 px-1.5 py-0.5 text-[9px] font-semibold text-amber-600">
+                        {badge.label}
+                      </span>
+                    ))}
                   </div>
                   <p className="mt-0.5 text-xs text-slate-500">
-                    {homeFeedData.heroBreeder.score.toLocaleString()}점 ·{" "}
-                    {formatRankDelta(homeFeedData.heroBreeder.rankDelta)}
+                    {homeFeedData.heroBreeder.score.toLocaleString()}점 · {formatRankDelta(homeFeedData.heroBreeder.rankDelta)}
                   </p>
                 </div>
                 <button
@@ -496,7 +412,7 @@ const MainClient = ({
                     router.push(
                       user
                         ? toRankingHref("breeders", "weekly")
-                        : "/auth/login?next=%2Franking%3Ftab%3Dbreeders%26period%3Dweekly",
+                        : "/auth/login?next=%2Franking%3Ftab%3Dbreeders%26period%3Dweekly"
                     );
                   }}
                   className="shrink-0 rounded-full bg-slate-900 px-3 py-1.5 text-[11px] font-semibold text-white transition-colors hover:bg-slate-800"
@@ -508,29 +424,19 @@ const MainClient = ({
               <div className="flex border-t border-slate-100 divide-x divide-slate-100">
                 {[
                   { label: "게시", value: homeFeedData.heroBreeder.postsCount },
-                  {
-                    label: "댓글",
-                    value: homeFeedData.heroBreeder.commentsCount,
-                  },
+                  { label: "댓글", value: homeFeedData.heroBreeder.commentsCount },
                   { label: "입찰", value: homeFeedData.heroBreeder.bidsCount },
-                  {
-                    label: "낙찰",
-                    value: homeFeedData.heroBreeder.auctionWinsCount,
-                  },
+                  { label: "낙찰", value: homeFeedData.heroBreeder.auctionWinsCount },
                 ].map((stat) => (
                   <div key={stat.label} className="flex-1 py-2.5 text-center">
-                    <p className="text-sm font-bold text-slate-900">
-                      {stat.value}
-                    </p>
+                    <p className="text-sm font-bold text-slate-900">{stat.value}</p>
                     <p className="text-[10px] text-slate-400">{stat.label}</p>
                   </div>
                 ))}
               </div>
             </div>
           ) : (
-            <div className="app-card p-4 text-sm text-slate-400">
-              이번 주 브리더 집계가 준비 중입니다.
-            </div>
+            <div className="app-card p-4 text-sm text-slate-400">이번 주 브리더 집계가 준비 중입니다.</div>
           )}
         </div>
       </section>
@@ -545,8 +451,7 @@ const MainClient = ({
               trackEvent(ANALYTICS_EVENTS.rankingCardClick, {
                 ranking_type: "auction",
                 rank: 1,
-                entity_id:
-                  homeFeedData?.topAuctionsByCategory?.[0]?.auctionId ?? "",
+                entity_id: homeFeedData?.topAuctionsByCategory?.[0]?.auctionId ?? "",
                 section_id: "auction_ranking",
               })
             }
@@ -554,45 +459,34 @@ const MainClient = ({
           >
             <div>
               <div className="flex items-center justify-between">
-                <h3 className="text-sm font-bold text-slate-900">
-                  최고가 경매
-                </h3>
+                <h3 className="text-sm font-bold text-slate-900">최고가 경매</h3>
                 <span className="text-[10px] text-slate-400">더보기 ›</span>
               </div>
-              <p className="mt-0.5 text-[10px] text-slate-400">
-                카테고리별 최고 낙찰가
-              </p>
+              <p className="mt-0.5 text-[10px] text-slate-400">카테고리별 최고 낙찰가</p>
             </div>
             <div className="mt-2 space-y-1.5">
               {homeFeedData?.topAuctionsByCategory?.length ? (
-                homeFeedData.topAuctionsByCategory
-                  .slice(0, 2)
-                  .map((auction) => (
-                    <div
-                      key={auction.auctionId}
-                      className="flex items-center gap-2"
-                    >
-                      <div className="h-8 w-8 shrink-0 overflow-hidden rounded-lg bg-slate-100">
-                        {auction.photo ? (
-                          <Image
-                            src={makeImageUrl(auction.photo, "public")}
-                            alt={auction.title}
-                            width={32}
-                            height={32}
-                            className="h-full w-full object-cover"
-                          />
-                        ) : null}
-                      </div>
-                      <div className="min-w-0 flex-1">
-                        <p className="truncate text-xs font-medium text-slate-700">
-                          {auction.title}
-                        </p>
-                        <p className="text-[10px] text-primary font-semibold">
-                          {auction.currentPrice.toLocaleString()}원
-                        </p>
-                      </div>
+                homeFeedData.topAuctionsByCategory.slice(0, 2).map((auction) => (
+                  <div key={auction.auctionId} className="flex items-center gap-2">
+                    <div className="h-8 w-8 shrink-0 overflow-hidden rounded-lg bg-slate-100">
+                      {auction.photo ? (
+                        <Image
+                          src={makeImageUrl(auction.photo, "public")}
+                          alt={auction.title}
+                          width={32}
+                          height={32}
+                          className="h-full w-full object-cover"
+                        />
+                      ) : null}
                     </div>
-                  ))
+                    <div className="min-w-0 flex-1">
+                      <p className="truncate text-xs font-medium text-slate-700">{auction.title}</p>
+                      <p className="text-[10px] text-primary font-semibold">
+                        {auction.currentPrice.toLocaleString()}원
+                      </p>
+                    </div>
+                  </div>
+                ))
               ) : (
                 <p className="text-[10px] text-slate-400">집계 준비 중</p>
               )}
@@ -606,8 +500,7 @@ const MainClient = ({
               trackEvent(ANALYTICS_EVENTS.rankingCardClick, {
                 ranking_type: "bloodline",
                 rank: 1,
-                entity_id:
-                  homeFeedData?.topBloodlines?.[0]?.bloodlineRootId ?? "",
+                entity_id: homeFeedData?.topBloodlines?.[0]?.bloodlineRootId ?? "",
                 section_id: "bloodline_ranking",
               })
             }
@@ -615,22 +508,15 @@ const MainClient = ({
           >
             <div>
               <div className="flex items-center justify-between">
-                <h3 className="text-sm font-bold text-slate-900">
-                  인기 혈통 TOP
-                </h3>
+                <h3 className="text-sm font-bold text-slate-900">인기 혈통 TOP</h3>
                 <span className="text-[10px] text-slate-400">더보기 ›</span>
               </div>
-              <p className="mt-0.5 text-[10px] text-slate-400">
-                보유자 수 기준 랭킹
-              </p>
+              <p className="mt-0.5 text-[10px] text-slate-400">보유자 수 기준 랭킹</p>
             </div>
             <div className="mt-2 space-y-1.5">
               {homeFeedData?.topBloodlines?.length ? (
                 homeFeedData.topBloodlines.slice(0, 2).map((bloodline) => (
-                  <div
-                    key={bloodline.bloodlineRootId}
-                    className="flex items-center gap-2"
-                  >
+                  <div key={bloodline.bloodlineRootId} className="flex items-center gap-2">
                     <div className="h-8 w-8 shrink-0 overflow-hidden rounded-lg bg-slate-100">
                       {bloodline.image ? (
                         <Image
@@ -642,19 +528,13 @@ const MainClient = ({
                         />
                       ) : (
                         <div className="flex h-full w-full items-end bg-[linear-gradient(145deg,#111827,#1f2937_58%,#f59e0b)] p-1">
-                          <span className="text-[6px] font-semibold tracking-wider text-white/80">
-                            BL
-                          </span>
+                          <span className="text-[6px] font-semibold tracking-wider text-white/80">BL</span>
                         </div>
                       )}
                     </div>
                     <div className="min-w-0 flex-1">
-                      <p className="truncate text-xs font-medium text-slate-700">
-                        {bloodline.name}
-                      </p>
-                      <p className="text-[10px] text-slate-400">
-                        보유자 {bloodline.ownerCount}명
-                      </p>
+                      <p className="truncate text-xs font-medium text-slate-700">{bloodline.name}</p>
+                      <p className="text-[10px] text-slate-400">보유자 {bloodline.ownerCount}명</p>
                     </div>
                   </div>
                 ))
@@ -679,26 +559,18 @@ const MainClient = ({
           >
             <div>
               <div className="flex items-center justify-between">
-                <h3 className="text-sm font-bold text-slate-900">
-                  급상승 커뮤니티
-                </h3>
+                <h3 className="text-sm font-bold text-slate-900">급상승 커뮤니티</h3>
                 <span className="text-[10px] text-slate-400">더보기 ›</span>
               </div>
-              <p className="mt-0.5 text-[10px] text-slate-400">
-                {communitySubtitle}
-              </p>
+              <p className="mt-0.5 text-[10px] text-slate-400">{communitySubtitle}</p>
             </div>
             <div className="mt-2 space-y-1.5">
               {homeFeedData?.trendingPosts?.length ? (
                 homeFeedData.trendingPosts.slice(0, 2).map((item) => (
                   <div key={item.post.id} className="flex items-center gap-2">
                     <div className="min-w-0 flex-1">
-                      <p className="truncate text-xs font-medium text-slate-700">
-                        {item.post.title}
-                      </p>
-                      <p className="text-[10px] text-slate-400">
-                        #{item.rank} 상승중
-                      </p>
+                      <p className="truncate text-xs font-medium text-slate-700">{item.post.title}</p>
+                      <p className="text-[10px] text-slate-400">#{item.rank} 상승중</p>
                     </div>
                   </div>
                 ))
@@ -727,36 +599,28 @@ const MainClient = ({
                   <h3 className="text-sm font-bold text-slate-900">무료나눔</h3>
                   <span className="text-[10px] text-slate-400">더보기 ›</span>
                 </div>
-                <p className="mt-0.5 text-[10px] text-slate-400">
-                  가격 0원 · 지금 연락하세요
-                </p>
+                <p className="mt-0.5 text-[10px] text-slate-400">가격 0원 · 지금 연락하세요</p>
               </div>
               <div className="mt-2 space-y-1.5">
-                {homeFeedData.freeGiveawayProducts
-                  .slice(0, 2)
-                  .map((item: FreeProductItem) => (
-                    <div key={item.id} className="flex items-center gap-2">
-                      <div className="h-8 w-8 shrink-0 overflow-hidden rounded-lg bg-slate-100">
-                        {item.photos[0] ? (
-                          <Image
-                            src={makeImageUrl(item.photos[0], "public")}
-                            alt={item.name}
-                            width={32}
-                            height={32}
-                            className="h-full w-full object-cover"
-                          />
-                        ) : null}
-                      </div>
-                      <div className="min-w-0 flex-1">
-                        <p className="truncate text-xs font-medium text-slate-700">
-                          {item.name}
-                        </p>
-                        <p className="text-[10px] text-slate-400">
-                          {item.user.name}
-                        </p>
-                      </div>
+                {homeFeedData.freeGiveawayProducts.slice(0, 2).map((item: FreeProductItem) => (
+                  <div key={item.id} className="flex items-center gap-2">
+                    <div className="h-8 w-8 shrink-0 overflow-hidden rounded-lg bg-slate-100">
+                      {item.photos[0] ? (
+                        <Image
+                          src={makeImageUrl(item.photos[0], "public")}
+                          alt={item.name}
+                          width={32}
+                          height={32}
+                          className="h-full w-full object-cover"
+                        />
+                      ) : null}
                     </div>
-                  ))}
+                    <div className="min-w-0 flex-1">
+                      <p className="truncate text-xs font-medium text-slate-700">{item.name}</p>
+                      <p className="text-[10px] text-slate-400">{item.user.name}</p>
+                    </div>
+                  </div>
+                ))}
               </div>
             </Link>
           ) : (
@@ -765,12 +629,8 @@ const MainClient = ({
               className="app-card app-card-interactive flex flex-col items-center justify-center p-3 text-center"
             >
               <h3 className="text-sm font-bold text-slate-900">무료나눔</h3>
-              <p className="mt-2 text-xs text-slate-500">
-                아직 무료나눔이 없어요
-              </p>
-              <p className="mt-1 text-[10px] font-semibold text-primary">
-                첫 번째로 등록해보세요 ›
-              </p>
+              <p className="mt-2 text-xs text-slate-500">아직 무료나눔이 없어요</p>
+              <p className="mt-1 text-[10px] font-semibold text-primary">첫 번째로 등록해보세요 ›</p>
             </Link>
           )}
         </div>
@@ -790,7 +650,7 @@ const MainClient = ({
                     "flex-shrink-0 rounded-md px-3 py-1.5 text-sm transition-colors",
                     isActive
                       ? "bg-slate-900 font-semibold text-white"
-                      : "bg-slate-100 font-medium text-slate-600 hover:bg-slate-200",
+                      : "bg-slate-100 font-medium text-slate-600 hover:bg-slate-200"
                   )}
                 >
                   {tab.name}
@@ -805,11 +665,11 @@ const MainClient = ({
         <div className="flex items-end justify-between">
           <div>
             <h2 className="app-section-title">
-              {selectedCategory === "전체"
-                ? "전체 상품"
-                : `${selectedCategory} 상품`}
+              {selectedCategory === "전체" ? "전체 상품" : `${selectedCategory} 상품`}
             </h2>
-            <p className="mt-1 app-caption">최신 등록 순으로 노출됩니다.</p>
+            <p className="mt-1 app-caption">
+              최신 등록 순으로 노출됩니다.
+            </p>
           </div>
           <span className="app-count-chip">{loadedProductCount}개</span>
         </div>
@@ -845,22 +705,24 @@ const MainClient = ({
         )}
 
         {/* 결과 없을 때 */}
-        {data && data.length > 0 && data[0].products.length === 0 && (
-          <div className="flex flex-col items-center justify-center py-20 text-slate-400">
-            <p className="app-title-md text-slate-500">
-              상품 피드가 활발해질 준비 중이에요
-            </p>
-            <p className="app-body-sm mt-1">
-              지금 개체를 등록해 첫 상품을 올려보세요.
-            </p>
-            <Link
-              href="/products/upload"
-              className="mt-3 inline-flex h-9 items-center rounded-md bg-slate-900 px-3 text-xs font-semibold text-white"
-            >
-              상품 등록하러 가기
-            </Link>
-          </div>
-        )}
+        {data &&
+          data.length > 0 &&
+          data[0].products.length === 0 && (
+            <div className="flex flex-col items-center justify-center py-20 text-slate-400">
+              <p className="app-title-md text-slate-500">
+                상품 피드가 활발해질 준비 중이에요
+              </p>
+              <p className="app-body-sm mt-1">
+                지금 개체를 등록해 첫 상품을 올려보세요.
+              </p>
+              <Link
+                href="/products/upload"
+                className="mt-3 inline-flex h-9 items-center rounded-md bg-slate-900 px-3 text-xs font-semibold text-white"
+              >
+                상품 등록하러 가기
+              </Link>
+            </div>
+          )}
       </div>
 
       <FloatingButton href="/products/upload">
@@ -884,12 +746,9 @@ const MainClient = ({
       {showPostLoginGuide && (
         <div className="fixed inset-0 z-50 bg-black/50 px-4 py-8">
           <div className="mx-auto mt-16 w-full max-w-sm rounded-2xl border border-slate-200 bg-white p-5 shadow-2xl">
-            <h3 className="text-base font-semibold text-slate-900">
-              시작 설정
-            </h3>
+            <h3 className="text-base font-semibold text-slate-900">시작 설정</h3>
             <p className="mt-1 text-sm text-slate-600">
-              홈 화면 설치와 푸시 알림을 설정하면 새 소식을 빠르게 확인할 수
-              있습니다.
+              홈 화면 설치와 푸시 알림을 설정하면 새 소식을 빠르게 확인할 수 있습니다.
             </p>
             <div className="mt-4 flex flex-col gap-2.5">
               <button
@@ -899,7 +758,7 @@ const MainClient = ({
                   "h-11 rounded-xl text-sm font-semibold transition-colors",
                   deferredInstallPrompt
                     ? "bg-slate-900 text-white hover:bg-slate-800"
-                    : "bg-slate-100 text-slate-500",
+                    : "bg-slate-100 text-slate-500"
                 )}
                 disabled={!deferredInstallPrompt || installLoading}
               >

--- a/app/(web)/(main)/MainClient.tsx
+++ b/app/(web)/(main)/MainClient.tsx
@@ -264,54 +264,64 @@ const MainClient = ({
   return (
     <div className="app-page flex flex-col h-full">
       {/* Section 1: 상단 배너/히어로 */}
-      <section className="app-reveal">
+      <section className="app-reveal bg-white pb-1 pt-3">
         <div
           ref={bannerRef}
           onScroll={handleBannerScroll}
-          className="app-rail flex gap-0"
+          className="app-rail flex snap-x snap-mandatory gap-3 scroll-px-5 px-5"
         >
-            {banners.map((banner) => (
-              <Link
-                key={banner.id}
-                href={banner.href}
-                onClick={() =>
-                  trackEvent(ANALYTICS_EVENTS.homeBannerClicked, {
-                    banner_id: banner.id,
-                    banner_title: banner.title,
-                    banner_href: banner.href,
-                    user_id: user?.id || null,
-                  })
-                }
-                className={cn(
-                  "snap-start shrink-0 w-full app-card-interactive rounded-none border-0 shadow-none px-5 py-5 text-white bg-gradient-to-r relative overflow-hidden from-emerald-500 to-teal-500",
-                  banner.bgClass
-                )}
-              >
-                <span className="app-kicker text-white/75 relative z-10">Bredy</span>
-                <h2 className="mt-2 app-title-lg text-white relative z-10">{banner.title}</h2>
-                <p className="mt-1 app-body-sm text-white/90 line-clamp-2 relative z-10">
+          {banners.map((banner) => (
+            <Link
+              key={banner.id}
+              href={banner.href}
+              onClick={() =>
+                trackEvent(ANALYTICS_EVENTS.homeBannerClicked, {
+                  banner_id: banner.id,
+                  banner_title: banner.title,
+                  banner_href: banner.href,
+                  user_id: user?.id || null,
+                })
+              }
+              className={cn(
+                "app-card-interactive relative flex min-h-[132px] w-[calc(100vw-40px)] max-w-[calc(36rem-40px)] shrink-0 snap-start flex-col justify-between overflow-hidden rounded-xl border border-white/20 bg-gradient-to-br from-emerald-500 to-teal-500 px-4 py-4 text-white shadow-none",
+                banner.bgClass
+              )}
+            >
+              <div>
+                <span className="text-[11px] font-semibold leading-none text-white/70">
+                  Bredy
+                </span>
+                <h2 className="mt-2 text-[20px] font-extrabold leading-tight tracking-normal text-white">
+                  {banner.title}
+                </h2>
+                <p className="mt-1 line-clamp-2 text-[13px] font-medium leading-[1.45] tracking-normal text-white/85">
                   {banner.description}
                 </p>
-                <span className="mt-4 inline-flex h-7 items-center rounded-full bg-white/20 px-2.5 text-[11px] font-semibold text-white/95 backdrop-blur-sm relative z-10">
-                  자세히 보기
-                </span>
-                <div className="pointer-events-none absolute -right-8 -top-10 h-28 w-28 rounded-full bg-white/12" />
-              </Link>
-            ))}
-
-        </div>
-        <div className="mt-3 flex items-center justify-center gap-1.5">
-          {banners.map((banner, index: number) => (
-            <button
-              key={banner.id}
-              onClick={() => scrollToBanner(index)}
-              aria-label={`${index + 1}번 배너로 이동`}
-              className={cn(
-                "h-1.5 rounded-full transition-all",
-                activeBannerIndex === index ? "w-6 bg-slate-900" : "w-2 bg-slate-300"
-              )}
-            />
+              </div>
+              <span className="mt-4 inline-flex h-7 w-fit items-center rounded-md bg-white/15 px-2.5 text-[11px] font-bold text-white backdrop-blur-sm">
+                자세히 보기
+              </span>
+            </Link>
           ))}
+        </div>
+        <div className="mt-2 flex items-center justify-center">
+          <div className="inline-flex h-5 items-center gap-1 rounded-full border border-slate-200 bg-white px-2">
+            {banners.map((banner, index: number) => (
+              <button
+                key={banner.id}
+                type="button"
+                onClick={() => scrollToBanner(index)}
+                aria-label={`${index + 1}번 배너로 이동`}
+                aria-current={activeBannerIndex === index ? "true" : undefined}
+                className={cn(
+                  "h-1.5 rounded-full transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30",
+                  activeBannerIndex === index
+                    ? "w-4 bg-primary"
+                    : "w-1.5 bg-slate-200 hover:bg-slate-300"
+                )}
+              />
+            ))}
+          </div>
         </div>
       </section>
 

--- a/app/(web)/(main)/MainClient.tsx
+++ b/app/(web)/(main)/MainClient.tsx
@@ -327,40 +327,39 @@ const MainClient = ({
 
       {/* Section 2: 혈통카드 공유 챌린지 (compact) */}
       <section className="app-section app-reveal app-reveal-1 py-2">
-        <div className="relative mx-5 overflow-hidden rounded-2xl bg-gradient-to-br from-amber-400 via-orange-400 to-rose-500 p-3 text-white shadow-lg">
-          <div className="pointer-events-none absolute -right-4 -top-4 h-16 w-16 rounded-full bg-white/15 blur-xl" />
-          <div className="flex items-center justify-between gap-3">
-            <div className="min-w-0 flex-1">
-              <div className="flex items-center gap-2">
-                <span className="inline-flex items-center rounded-full bg-white/25 px-2 py-0.5 text-[9px] font-bold uppercase tracking-widest">
-                  이벤트
-                </span>
-                <h3 className="text-sm font-black leading-tight">혈통카드 공유 챌린지</h3>
-              </div>
-              <p className="mt-1 text-[11px] leading-snug text-white/90">
-                내 혈통카드를 공유하고 특별 배지를 받으세요!
-              </p>
+        <div className="mx-5 rounded-sm border border-slate-200 bg-white px-4 py-3">
+          <div className="min-w-0">
+            <div className="flex items-center gap-2">
+              <span className="inline-flex h-5 items-center rounded bg-primary/10 px-1.5 text-[10px] font-bold text-primary">
+                이벤트
+              </span>
+              <h3 className="text-sm font-extrabold tracking-normal text-slate-950">
+                혈통카드 공유 챌린지
+              </h3>
             </div>
-            <div className="flex shrink-0 gap-1.5">
-              <Link
-                href="/bloodline-management"
-                onClick={() =>
-                  trackEvent(ANALYTICS_EVENTS.challengeJoin, {
-                    challenge_id: "bloodline_card_share",
-                    entry_type: user ? "member" : "guest",
-                  })
-                }
-                className="inline-flex h-7 items-center rounded-full bg-white px-3 text-[11px] font-bold text-orange-600"
-              >
-                보기
-              </Link>
-              <Link
-                href="/bloodline-cards/create"
-                className="inline-flex h-7 items-center rounded-full border border-white/40 bg-white/20 px-3 text-[11px] font-semibold text-white backdrop-blur-sm"
-              >
-                만들기
-              </Link>
-            </div>
+            <p className="mt-1.5 text-xs font-medium tracking-normal text-slate-500">
+              내 혈통카드를 공유하고 특별 배지를 받아보세요.
+            </p>
+          </div>
+          <div className="mt-3 grid grid-cols-2 gap-2">
+            <Link
+              href="/bloodline-management"
+              onClick={() =>
+                trackEvent(ANALYTICS_EVENTS.challengeJoin, {
+                  challenge_id: "bloodline_card_share",
+                  entry_type: user ? "member" : "guest",
+                })
+              }
+              className="inline-flex h-9 items-center justify-center rounded-sm bg-slate-950 px-3 text-xs font-bold text-white transition hover:bg-slate-800"
+            >
+              보기
+            </Link>
+            <Link
+              href="/bloodline-cards/create"
+              className="inline-flex h-9 items-center justify-center rounded-sm border border-slate-200 bg-white px-3 text-xs font-bold text-slate-700 transition hover:bg-slate-50"
+            >
+              만들기
+            </Link>
           </div>
         </div>
       </section>

--- a/app/(web)/(main)/MainClient.tsx
+++ b/app/(web)/(main)/MainClient.tsx
@@ -64,9 +64,42 @@ const formatRankDelta = (rankDelta: number) => {
   return "유지";
 };
 
+const getBannerTone = (bgClass: string) => {
+  if (bgClass.includes("orange") || bgClass.includes("amber")) {
+    return {
+      card: "border-orange-100 bg-orange-50/45",
+      chip: "border-orange-100 bg-white text-orange-700",
+      visual: "border-orange-100 bg-orange-100 text-orange-700",
+    };
+  }
 
-const toRankingHref = (tab: "breeders" | "auctions" | "bloodlines" | "community", period: "weekly" | "all") =>
-  `/ranking?tab=${tab}&period=${period}`;
+  if (bgClass.includes("sky") || bgClass.includes("cyan")) {
+    return {
+      card: "border-blue-100 bg-blue-50/45",
+      chip: "border-blue-100 bg-white text-blue-700",
+      visual: "border-blue-100 bg-blue-100 text-blue-700",
+    };
+  }
+
+  if (bgClass.includes("emerald") || bgClass.includes("teal")) {
+    return {
+      card: "border-emerald-100 bg-emerald-50/45",
+      chip: "border-emerald-100 bg-white text-emerald-700",
+      visual: "border-emerald-100 bg-emerald-100 text-emerald-700",
+    };
+  }
+
+  return {
+    card: "border-slate-200 bg-white",
+    chip: "border-slate-200 bg-slate-50 text-slate-700",
+    visual: "border-slate-200 bg-slate-100 text-slate-700",
+  };
+};
+
+const toRankingHref = (
+  tab: "breeders" | "auctions" | "bloodlines" | "community",
+  period: "weekly" | "all",
+) => `/ranking?tab=${tab}&period=${period}`;
 
 const MainClient = ({
   initialHomeFeed,
@@ -89,7 +122,7 @@ const MainClient = ({
 
   const getKey = (
     pageIndex: number,
-    previousPageData: ProductsResponse | null
+    previousPageData: ProductsResponse | null,
   ) => {
     if (previousPageData && !previousPageData.products.length) return null;
     const categoryParam =
@@ -113,7 +146,7 @@ const MainClient = ({
       revalidateOnFocus: false,
       revalidateOnMount: false,
       revalidateIfStale: false,
-    }
+    },
   );
   const banners = initialBanners;
 
@@ -253,12 +286,18 @@ const MainClient = ({
   };
 
   const loadedProductCount =
-    data?.reduce((count, pageData) => count + (pageData?.products?.length ?? 0), 0) ?? 0;
+    data?.reduce(
+      (count, pageData) => count + (pageData?.products?.length ?? 0),
+      0,
+    ) ?? 0;
   const heroBreederPeriod = homeFeedData?.heroBreederMode ?? "weekly";
-  const auctionPeriod = homeFeedData?.topAuctionsMode === "all" ? "all" : "weekly";
+  const auctionPeriod =
+    homeFeedData?.topAuctionsMode === "all" ? "all" : "weekly";
   const bloodlinePeriod = homeFeedData?.topBloodlinesMode ?? "weekly";
-  const communityPeriod = homeFeedData?.trendingPostsMode === "all" ? "all" : "weekly";
-  const bloodlineSubtitle = "가장 많은 사용자가 보유한 혈통카드를 기준으로 집계한 랭킹";
+  const communityPeriod =
+    homeFeedData?.trendingPostsMode === "all" ? "all" : "weekly";
+  const bloodlineSubtitle =
+    "가장 많은 사용자가 보유한 혈통카드를 기준으로 집계한 랭킹";
   const communitySubtitle = "좋아요와 댓글 반응이 높은 커뮤니티 글";
 
   return (
@@ -268,9 +307,11 @@ const MainClient = ({
         <div
           ref={bannerRef}
           onScroll={handleBannerScroll}
-          className="app-rail flex gap-0"
+          className="app-rail flex gap-3 px-4 py-1"
         >
-            {banners.map((banner) => (
+          {banners.map((banner) => {
+            const tone = getBannerTone(banner.bgClass);
+            return (
               <Link
                 key={banner.id}
                 href={banner.href}
@@ -283,32 +324,64 @@ const MainClient = ({
                   })
                 }
                 className={cn(
-                  "snap-start shrink-0 w-full app-card-interactive rounded-none border-0 shadow-none px-5 py-5 text-white bg-gradient-to-r relative overflow-hidden from-emerald-500 to-teal-500",
-                  banner.bgClass
+                  "snap-start flex min-h-[128px] w-[calc(100%-28px)] shrink-0 items-stretch justify-between gap-4 overflow-hidden rounded-xl border p-4 text-slate-950 shadow-none transition-colors",
+                  "sm:w-[calc(100%-40px)]",
+                  tone.card,
                 )}
               >
-                <span className="app-kicker text-white/75 relative z-10">Bredy</span>
-                <h2 className="mt-2 app-title-lg text-white relative z-10">{banner.title}</h2>
-                <p className="mt-1 app-body-sm text-white/90 line-clamp-2 relative z-10">
-                  {banner.description}
-                </p>
-                <span className="mt-4 inline-flex h-7 items-center rounded-full bg-white/20 px-2.5 text-[11px] font-semibold text-white/95 backdrop-blur-sm relative z-10">
-                  자세히 보기
-                </span>
-                <div className="pointer-events-none absolute -right-8 -top-10 h-28 w-28 rounded-full bg-white/12" />
+                <div className="min-w-0 flex-1 self-center">
+                  <span
+                    className={cn(
+                      "inline-flex h-6 items-center rounded-full border px-2 text-[11px] font-semibold",
+                      tone.chip,
+                    )}
+                  >
+                    Bredy
+                  </span>
+                  <h2 className="mt-2 line-clamp-1 text-[18px] font-bold text-slate-950">
+                    {banner.title}
+                  </h2>
+                  <p className="mt-1 line-clamp-2 text-[13px] font-medium text-slate-500">
+                    {banner.description}
+                  </p>
+                  <span className="mt-3 inline-flex text-[13px] font-semibold text-slate-900">
+                    자세히 보기 ›
+                  </span>
+                </div>
+                <div
+                  className={cn(
+                    "relative flex h-24 w-24 shrink-0 items-center justify-center overflow-hidden rounded-lg border",
+                    tone.visual,
+                  )}
+                >
+                  {banner.image ? (
+                    <Image
+                      src={makeImageUrl(banner.image, "public")}
+                      alt=""
+                      width={96}
+                      height={96}
+                      className="h-full w-full object-cover"
+                    />
+                  ) : (
+                    <span className="text-xl font-black">B</span>
+                  )}
+                </div>
               </Link>
-            ))}
-
+            );
+          })}
         </div>
-        <div className="mt-3 flex items-center justify-center gap-1.5">
+        <div className="mt-2 flex items-center gap-1 px-5">
           {banners.map((banner, index: number) => (
             <button
               key={banner.id}
               onClick={() => scrollToBanner(index)}
               aria-label={`${index + 1}번 배너로 이동`}
+              aria-current={activeBannerIndex === index ? "true" : undefined}
               className={cn(
-                "h-1.5 rounded-full transition-all",
-                activeBannerIndex === index ? "w-6 bg-slate-900" : "w-2 bg-slate-300"
+                "h-1 rounded-full transition-all",
+                activeBannerIndex === index
+                  ? "w-5 bg-slate-900"
+                  : "w-2 bg-slate-300",
               )}
             />
           ))}
@@ -325,7 +398,9 @@ const MainClient = ({
                 <span className="inline-flex items-center rounded-full bg-white/25 px-2 py-0.5 text-[9px] font-bold uppercase tracking-widest">
                   이벤트
                 </span>
-                <h3 className="text-sm font-black leading-tight">혈통카드 공유 챌린지</h3>
+                <h3 className="text-sm font-black leading-tight">
+                  혈통카드 공유 챌린지
+                </h3>
               </div>
               <p className="mt-1 text-[11px] leading-snug text-white/90">
                 내 혈통카드를 공유하고 특별 배지를 받으세요!
@@ -371,7 +446,10 @@ const MainClient = ({
                   <div className="h-11 w-11 overflow-hidden rounded-full bg-slate-100 ring-2 ring-amber-400/60">
                     {homeFeedData.heroBreeder.user.avatar ? (
                       <Image
-                        src={makeImageUrl(homeFeedData.heroBreeder.user.avatar, "avatar")}
+                        src={makeImageUrl(
+                          homeFeedData.heroBreeder.user.avatar,
+                          "avatar",
+                        )}
                         alt={homeFeedData.heroBreeder.user.name}
                         width={44}
                         height={44}
@@ -392,14 +470,20 @@ const MainClient = ({
                     <h3 className="truncate text-sm font-bold text-slate-900">
                       {homeFeedData.heroBreeder.user.name}
                     </h3>
-                    {(homeFeedData.heroBreeder.badges || []).slice(0, 1).map((badge) => (
-                      <span key={badge.id} className="shrink-0 rounded bg-amber-50 px-1.5 py-0.5 text-[9px] font-semibold text-amber-600">
-                        {badge.label}
-                      </span>
-                    ))}
+                    {(homeFeedData.heroBreeder.badges || [])
+                      .slice(0, 1)
+                      .map((badge) => (
+                        <span
+                          key={badge.id}
+                          className="shrink-0 rounded bg-amber-50 px-1.5 py-0.5 text-[9px] font-semibold text-amber-600"
+                        >
+                          {badge.label}
+                        </span>
+                      ))}
                   </div>
                   <p className="mt-0.5 text-xs text-slate-500">
-                    {homeFeedData.heroBreeder.score.toLocaleString()}점 · {formatRankDelta(homeFeedData.heroBreeder.rankDelta)}
+                    {homeFeedData.heroBreeder.score.toLocaleString()}점 ·{" "}
+                    {formatRankDelta(homeFeedData.heroBreeder.rankDelta)}
                   </p>
                 </div>
                 <button
@@ -412,7 +496,7 @@ const MainClient = ({
                     router.push(
                       user
                         ? toRankingHref("breeders", "weekly")
-                        : "/auth/login?next=%2Franking%3Ftab%3Dbreeders%26period%3Dweekly"
+                        : "/auth/login?next=%2Franking%3Ftab%3Dbreeders%26period%3Dweekly",
                     );
                   }}
                   className="shrink-0 rounded-full bg-slate-900 px-3 py-1.5 text-[11px] font-semibold text-white transition-colors hover:bg-slate-800"
@@ -424,19 +508,29 @@ const MainClient = ({
               <div className="flex border-t border-slate-100 divide-x divide-slate-100">
                 {[
                   { label: "게시", value: homeFeedData.heroBreeder.postsCount },
-                  { label: "댓글", value: homeFeedData.heroBreeder.commentsCount },
+                  {
+                    label: "댓글",
+                    value: homeFeedData.heroBreeder.commentsCount,
+                  },
                   { label: "입찰", value: homeFeedData.heroBreeder.bidsCount },
-                  { label: "낙찰", value: homeFeedData.heroBreeder.auctionWinsCount },
+                  {
+                    label: "낙찰",
+                    value: homeFeedData.heroBreeder.auctionWinsCount,
+                  },
                 ].map((stat) => (
                   <div key={stat.label} className="flex-1 py-2.5 text-center">
-                    <p className="text-sm font-bold text-slate-900">{stat.value}</p>
+                    <p className="text-sm font-bold text-slate-900">
+                      {stat.value}
+                    </p>
                     <p className="text-[10px] text-slate-400">{stat.label}</p>
                   </div>
                 ))}
               </div>
             </div>
           ) : (
-            <div className="app-card p-4 text-sm text-slate-400">이번 주 브리더 집계가 준비 중입니다.</div>
+            <div className="app-card p-4 text-sm text-slate-400">
+              이번 주 브리더 집계가 준비 중입니다.
+            </div>
           )}
         </div>
       </section>
@@ -451,7 +545,8 @@ const MainClient = ({
               trackEvent(ANALYTICS_EVENTS.rankingCardClick, {
                 ranking_type: "auction",
                 rank: 1,
-                entity_id: homeFeedData?.topAuctionsByCategory?.[0]?.auctionId ?? "",
+                entity_id:
+                  homeFeedData?.topAuctionsByCategory?.[0]?.auctionId ?? "",
                 section_id: "auction_ranking",
               })
             }
@@ -459,34 +554,45 @@ const MainClient = ({
           >
             <div>
               <div className="flex items-center justify-between">
-                <h3 className="text-sm font-bold text-slate-900">최고가 경매</h3>
+                <h3 className="text-sm font-bold text-slate-900">
+                  최고가 경매
+                </h3>
                 <span className="text-[10px] text-slate-400">더보기 ›</span>
               </div>
-              <p className="mt-0.5 text-[10px] text-slate-400">카테고리별 최고 낙찰가</p>
+              <p className="mt-0.5 text-[10px] text-slate-400">
+                카테고리별 최고 낙찰가
+              </p>
             </div>
             <div className="mt-2 space-y-1.5">
               {homeFeedData?.topAuctionsByCategory?.length ? (
-                homeFeedData.topAuctionsByCategory.slice(0, 2).map((auction) => (
-                  <div key={auction.auctionId} className="flex items-center gap-2">
-                    <div className="h-8 w-8 shrink-0 overflow-hidden rounded-lg bg-slate-100">
-                      {auction.photo ? (
-                        <Image
-                          src={makeImageUrl(auction.photo, "public")}
-                          alt={auction.title}
-                          width={32}
-                          height={32}
-                          className="h-full w-full object-cover"
-                        />
-                      ) : null}
+                homeFeedData.topAuctionsByCategory
+                  .slice(0, 2)
+                  .map((auction) => (
+                    <div
+                      key={auction.auctionId}
+                      className="flex items-center gap-2"
+                    >
+                      <div className="h-8 w-8 shrink-0 overflow-hidden rounded-lg bg-slate-100">
+                        {auction.photo ? (
+                          <Image
+                            src={makeImageUrl(auction.photo, "public")}
+                            alt={auction.title}
+                            width={32}
+                            height={32}
+                            className="h-full w-full object-cover"
+                          />
+                        ) : null}
+                      </div>
+                      <div className="min-w-0 flex-1">
+                        <p className="truncate text-xs font-medium text-slate-700">
+                          {auction.title}
+                        </p>
+                        <p className="text-[10px] text-primary font-semibold">
+                          {auction.currentPrice.toLocaleString()}원
+                        </p>
+                      </div>
                     </div>
-                    <div className="min-w-0 flex-1">
-                      <p className="truncate text-xs font-medium text-slate-700">{auction.title}</p>
-                      <p className="text-[10px] text-primary font-semibold">
-                        {auction.currentPrice.toLocaleString()}원
-                      </p>
-                    </div>
-                  </div>
-                ))
+                  ))
               ) : (
                 <p className="text-[10px] text-slate-400">집계 준비 중</p>
               )}
@@ -500,7 +606,8 @@ const MainClient = ({
               trackEvent(ANALYTICS_EVENTS.rankingCardClick, {
                 ranking_type: "bloodline",
                 rank: 1,
-                entity_id: homeFeedData?.topBloodlines?.[0]?.bloodlineRootId ?? "",
+                entity_id:
+                  homeFeedData?.topBloodlines?.[0]?.bloodlineRootId ?? "",
                 section_id: "bloodline_ranking",
               })
             }
@@ -508,15 +615,22 @@ const MainClient = ({
           >
             <div>
               <div className="flex items-center justify-between">
-                <h3 className="text-sm font-bold text-slate-900">인기 혈통 TOP</h3>
+                <h3 className="text-sm font-bold text-slate-900">
+                  인기 혈통 TOP
+                </h3>
                 <span className="text-[10px] text-slate-400">더보기 ›</span>
               </div>
-              <p className="mt-0.5 text-[10px] text-slate-400">보유자 수 기준 랭킹</p>
+              <p className="mt-0.5 text-[10px] text-slate-400">
+                보유자 수 기준 랭킹
+              </p>
             </div>
             <div className="mt-2 space-y-1.5">
               {homeFeedData?.topBloodlines?.length ? (
                 homeFeedData.topBloodlines.slice(0, 2).map((bloodline) => (
-                  <div key={bloodline.bloodlineRootId} className="flex items-center gap-2">
+                  <div
+                    key={bloodline.bloodlineRootId}
+                    className="flex items-center gap-2"
+                  >
                     <div className="h-8 w-8 shrink-0 overflow-hidden rounded-lg bg-slate-100">
                       {bloodline.image ? (
                         <Image
@@ -528,13 +642,19 @@ const MainClient = ({
                         />
                       ) : (
                         <div className="flex h-full w-full items-end bg-[linear-gradient(145deg,#111827,#1f2937_58%,#f59e0b)] p-1">
-                          <span className="text-[6px] font-semibold tracking-wider text-white/80">BL</span>
+                          <span className="text-[6px] font-semibold tracking-wider text-white/80">
+                            BL
+                          </span>
                         </div>
                       )}
                     </div>
                     <div className="min-w-0 flex-1">
-                      <p className="truncate text-xs font-medium text-slate-700">{bloodline.name}</p>
-                      <p className="text-[10px] text-slate-400">보유자 {bloodline.ownerCount}명</p>
+                      <p className="truncate text-xs font-medium text-slate-700">
+                        {bloodline.name}
+                      </p>
+                      <p className="text-[10px] text-slate-400">
+                        보유자 {bloodline.ownerCount}명
+                      </p>
                     </div>
                   </div>
                 ))
@@ -559,18 +679,26 @@ const MainClient = ({
           >
             <div>
               <div className="flex items-center justify-between">
-                <h3 className="text-sm font-bold text-slate-900">급상승 커뮤니티</h3>
+                <h3 className="text-sm font-bold text-slate-900">
+                  급상승 커뮤니티
+                </h3>
                 <span className="text-[10px] text-slate-400">더보기 ›</span>
               </div>
-              <p className="mt-0.5 text-[10px] text-slate-400">{communitySubtitle}</p>
+              <p className="mt-0.5 text-[10px] text-slate-400">
+                {communitySubtitle}
+              </p>
             </div>
             <div className="mt-2 space-y-1.5">
               {homeFeedData?.trendingPosts?.length ? (
                 homeFeedData.trendingPosts.slice(0, 2).map((item) => (
                   <div key={item.post.id} className="flex items-center gap-2">
                     <div className="min-w-0 flex-1">
-                      <p className="truncate text-xs font-medium text-slate-700">{item.post.title}</p>
-                      <p className="text-[10px] text-slate-400">#{item.rank} 상승중</p>
+                      <p className="truncate text-xs font-medium text-slate-700">
+                        {item.post.title}
+                      </p>
+                      <p className="text-[10px] text-slate-400">
+                        #{item.rank} 상승중
+                      </p>
                     </div>
                   </div>
                 ))
@@ -599,28 +727,36 @@ const MainClient = ({
                   <h3 className="text-sm font-bold text-slate-900">무료나눔</h3>
                   <span className="text-[10px] text-slate-400">더보기 ›</span>
                 </div>
-                <p className="mt-0.5 text-[10px] text-slate-400">가격 0원 · 지금 연락하세요</p>
+                <p className="mt-0.5 text-[10px] text-slate-400">
+                  가격 0원 · 지금 연락하세요
+                </p>
               </div>
               <div className="mt-2 space-y-1.5">
-                {homeFeedData.freeGiveawayProducts.slice(0, 2).map((item: FreeProductItem) => (
-                  <div key={item.id} className="flex items-center gap-2">
-                    <div className="h-8 w-8 shrink-0 overflow-hidden rounded-lg bg-slate-100">
-                      {item.photos[0] ? (
-                        <Image
-                          src={makeImageUrl(item.photos[0], "public")}
-                          alt={item.name}
-                          width={32}
-                          height={32}
-                          className="h-full w-full object-cover"
-                        />
-                      ) : null}
+                {homeFeedData.freeGiveawayProducts
+                  .slice(0, 2)
+                  .map((item: FreeProductItem) => (
+                    <div key={item.id} className="flex items-center gap-2">
+                      <div className="h-8 w-8 shrink-0 overflow-hidden rounded-lg bg-slate-100">
+                        {item.photos[0] ? (
+                          <Image
+                            src={makeImageUrl(item.photos[0], "public")}
+                            alt={item.name}
+                            width={32}
+                            height={32}
+                            className="h-full w-full object-cover"
+                          />
+                        ) : null}
+                      </div>
+                      <div className="min-w-0 flex-1">
+                        <p className="truncate text-xs font-medium text-slate-700">
+                          {item.name}
+                        </p>
+                        <p className="text-[10px] text-slate-400">
+                          {item.user.name}
+                        </p>
+                      </div>
                     </div>
-                    <div className="min-w-0 flex-1">
-                      <p className="truncate text-xs font-medium text-slate-700">{item.name}</p>
-                      <p className="text-[10px] text-slate-400">{item.user.name}</p>
-                    </div>
-                  </div>
-                ))}
+                  ))}
               </div>
             </Link>
           ) : (
@@ -629,8 +765,12 @@ const MainClient = ({
               className="app-card app-card-interactive flex flex-col items-center justify-center p-3 text-center"
             >
               <h3 className="text-sm font-bold text-slate-900">무료나눔</h3>
-              <p className="mt-2 text-xs text-slate-500">아직 무료나눔이 없어요</p>
-              <p className="mt-1 text-[10px] font-semibold text-primary">첫 번째로 등록해보세요 ›</p>
+              <p className="mt-2 text-xs text-slate-500">
+                아직 무료나눔이 없어요
+              </p>
+              <p className="mt-1 text-[10px] font-semibold text-primary">
+                첫 번째로 등록해보세요 ›
+              </p>
             </Link>
           )}
         </div>
@@ -650,7 +790,7 @@ const MainClient = ({
                     "flex-shrink-0 rounded-md px-3 py-1.5 text-sm transition-colors",
                     isActive
                       ? "bg-slate-900 font-semibold text-white"
-                      : "bg-slate-100 font-medium text-slate-600 hover:bg-slate-200"
+                      : "bg-slate-100 font-medium text-slate-600 hover:bg-slate-200",
                   )}
                 >
                   {tab.name}
@@ -665,11 +805,11 @@ const MainClient = ({
         <div className="flex items-end justify-between">
           <div>
             <h2 className="app-section-title">
-              {selectedCategory === "전체" ? "전체 상품" : `${selectedCategory} 상품`}
+              {selectedCategory === "전체"
+                ? "전체 상품"
+                : `${selectedCategory} 상품`}
             </h2>
-            <p className="mt-1 app-caption">
-              최신 등록 순으로 노출됩니다.
-            </p>
+            <p className="mt-1 app-caption">최신 등록 순으로 노출됩니다.</p>
           </div>
           <span className="app-count-chip">{loadedProductCount}개</span>
         </div>
@@ -705,24 +845,22 @@ const MainClient = ({
         )}
 
         {/* 결과 없을 때 */}
-        {data &&
-          data.length > 0 &&
-          data[0].products.length === 0 && (
-            <div className="flex flex-col items-center justify-center py-20 text-slate-400">
-              <p className="app-title-md text-slate-500">
-                상품 피드가 활발해질 준비 중이에요
-              </p>
-              <p className="app-body-sm mt-1">
-                지금 개체를 등록해 첫 상품을 올려보세요.
-              </p>
-              <Link
-                href="/products/upload"
-                className="mt-3 inline-flex h-9 items-center rounded-md bg-slate-900 px-3 text-xs font-semibold text-white"
-              >
-                상품 등록하러 가기
-              </Link>
-            </div>
-          )}
+        {data && data.length > 0 && data[0].products.length === 0 && (
+          <div className="flex flex-col items-center justify-center py-20 text-slate-400">
+            <p className="app-title-md text-slate-500">
+              상품 피드가 활발해질 준비 중이에요
+            </p>
+            <p className="app-body-sm mt-1">
+              지금 개체를 등록해 첫 상품을 올려보세요.
+            </p>
+            <Link
+              href="/products/upload"
+              className="mt-3 inline-flex h-9 items-center rounded-md bg-slate-900 px-3 text-xs font-semibold text-white"
+            >
+              상품 등록하러 가기
+            </Link>
+          </div>
+        )}
       </div>
 
       <FloatingButton href="/products/upload">
@@ -746,9 +884,12 @@ const MainClient = ({
       {showPostLoginGuide && (
         <div className="fixed inset-0 z-50 bg-black/50 px-4 py-8">
           <div className="mx-auto mt-16 w-full max-w-sm rounded-2xl border border-slate-200 bg-white p-5 shadow-2xl">
-            <h3 className="text-base font-semibold text-slate-900">시작 설정</h3>
+            <h3 className="text-base font-semibold text-slate-900">
+              시작 설정
+            </h3>
             <p className="mt-1 text-sm text-slate-600">
-              홈 화면 설치와 푸시 알림을 설정하면 새 소식을 빠르게 확인할 수 있습니다.
+              홈 화면 설치와 푸시 알림을 설정하면 새 소식을 빠르게 확인할 수
+              있습니다.
             </p>
             <div className="mt-4 flex flex-col gap-2.5">
               <button
@@ -758,7 +899,7 @@ const MainClient = ({
                   "h-11 rounded-xl text-sm font-semibold transition-colors",
                   deferredInstallPrompt
                     ? "bg-slate-900 text-white hover:bg-slate-800"
-                    : "bg-slate-100 text-slate-500"
+                    : "bg-slate-100 text-slate-500",
                 )}
                 disabled={!deferredInstallPrompt || installLoading}
               >

--- a/app/(web)/(main)/MainClient.tsx
+++ b/app/(web)/(main)/MainClient.tsx
@@ -366,13 +366,13 @@ const MainClient = ({
       </section>
 
       {/* Section 3: TOP 브리더 */}
-      <section className="app-section app-reveal app-reveal-1 py-2">
+      <section className="app-section app-reveal app-reveal-1 pt-4 pb-2">
         <SectionHeader
           title="이번 주 TOP 브리더"
           href={toRankingHref("breeders", heroBreederPeriod)}
           actionLabel="랭킹 보기"
         />
-        <div className="mt-1 px-5">
+        <div className="mt-3 px-5">
           {homeFeedData?.heroBreeder ? (
             <div className="app-card overflow-hidden border border-slate-200/80 p-0">
               {/* 상단: 프로필 + 순위 */}

--- a/app/(web)/(main)/MainClient.tsx
+++ b/app/(web)/(main)/MainClient.tsx
@@ -264,7 +264,7 @@ const MainClient = ({
   return (
     <div className="app-page flex flex-col h-full">
       {/* Section 1: 상단 배너/히어로 */}
-      <section className="app-reveal bg-white pb-1 pt-3">
+      <section className="app-reveal relative bg-white pb-1 pt-3">
         <div
           ref={bannerRef}
           onScroll={handleBannerScroll}
@@ -304,8 +304,8 @@ const MainClient = ({
             </Link>
           ))}
         </div>
-        <div className="mt-2 flex items-center justify-center">
-          <div className="inline-flex h-5 items-center gap-1 rounded-full border border-slate-200 bg-white px-2">
+        {banners.length > 1 ? (
+          <div className="pointer-events-none absolute inset-x-0 bottom-4 flex items-center justify-center">
             {banners.map((banner, index: number) => (
               <button
                 key={banner.id}
@@ -313,16 +313,18 @@ const MainClient = ({
                 onClick={() => scrollToBanner(index)}
                 aria-label={`${index + 1}번 배너로 이동`}
                 aria-current={activeBannerIndex === index ? "true" : undefined}
-                className={cn(
-                  "h-1.5 rounded-full transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30",
-                  activeBannerIndex === index
-                    ? "w-4 bg-primary"
-                    : "w-1.5 bg-slate-200 hover:bg-slate-300"
-                )}
-              />
+                className="pointer-events-auto grid h-4 w-4 place-items-center rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/30"
+              >
+                <span
+                  className={cn(
+                    "h-1.5 w-1.5 rounded-full transition-colors",
+                    activeBannerIndex === index ? "bg-black" : "bg-black/25"
+                  )}
+                />
+              </button>
             ))}
           </div>
-        </div>
+        ) : null}
       </section>
 
       {/* Section 2: 혈통카드 공유 챌린지 (compact) */}

--- a/app/(web)/bloodline-management/BloodlineManagementClient.tsx
+++ b/app/(web)/bloodline-management/BloodlineManagementClient.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import useSWR from "swr";
 import { Spinner } from "@components/atoms/Spinner";
+import Layout from "@components/features/MainLayout";
 import useUser from "hooks/useUser";
 import {
   BloodlineCardItem,
@@ -256,59 +257,61 @@ export default function BloodlineManagementClient() {
   };
 
   return (
-    <div className="app-page min-h-screen">
-      <div className="mx-auto flex w-full max-w-[680px] flex-col gap-4">
-        <header className="space-y-3">
-          <div className="rounded-lg border border-slate-200 bg-white p-4">
-            <p className="text-xs font-semibold text-primary">
-              BLOODLINE MANAGEMENT
-            </p>
-            <div className="mt-2 flex items-center justify-between gap-2">
-              <h1 className="app-title-lg">혈통관리</h1>
-              <Link
-                href="/bloodline-cards/create"
-                className="inline-flex h-9 items-center justify-center rounded-lg bg-slate-900 px-3 text-xs font-semibold text-white transition hover:bg-slate-800"
-              >
-                새 혈통 만들기
-              </Link>
-            </div>
-            <p className="mt-1 text-sm text-slate-600">
-              카드를 선택하면 상세에서 보내기와 라인 만들기를 바로 이어서 진행할
-              수 있습니다.
-            </p>
-            <div className="mt-3 grid grid-cols-2 gap-2 text-sm">
-              <div className="rounded-lg bg-slate-50 px-3 py-2">
-                <p className="text-[11px] font-semibold text-slate-500">
-                  총 자산
-                </p>
-                <p className="mt-1 text-lg font-bold text-slate-900">
-                  {totalCards}개
-                </p>
+    <Layout canGoBack hasTabBar showHome title="혈통관리" seoTitle="혈통관리">
+      <div className="px-4 py-4">
+        <div className="mx-auto flex w-full max-w-[680px] flex-col gap-4">
+          <header className="space-y-3">
+            <div className="rounded-lg border border-slate-200 bg-white p-4">
+              <p className="text-xs font-semibold text-primary">
+                BLOODLINE MANAGEMENT
+              </p>
+              <div className="mt-2 flex items-center justify-between gap-2">
+                <h1 className="app-title-lg">혈통관리</h1>
+                <Link
+                  href="/bloodline-cards/create"
+                  className="inline-flex h-9 items-center justify-center rounded-lg bg-slate-900 px-3 text-xs font-semibold text-white transition hover:bg-slate-800"
+                >
+                  새 혈통 만들기
+                </Link>
               </div>
-              <div className="rounded-lg bg-slate-50 px-3 py-2">
-                <p className="text-[11px] font-semibold text-slate-500">
-                  내 구성
-                </p>
-                <p className="mt-1 text-lg font-bold text-slate-900">
-                  {directCards}개
-                </p>
+              <p className="mt-1 text-sm text-slate-600">
+                카드를 선택하면 상세에서 보내기와 라인 만들기를 바로 이어서
+                진행할 수 있습니다.
+              </p>
+              <div className="mt-3 grid grid-cols-2 gap-2 text-sm">
+                <div className="rounded-lg bg-slate-50 px-3 py-2">
+                  <p className="text-[11px] font-semibold text-slate-500">
+                    총 자산
+                  </p>
+                  <p className="mt-1 text-lg font-bold text-slate-900">
+                    {totalCards}개
+                  </p>
+                </div>
+                <div className="rounded-lg bg-slate-50 px-3 py-2">
+                  <p className="text-[11px] font-semibold text-slate-500">
+                    내 구성
+                  </p>
+                  <p className="mt-1 text-lg font-bold text-slate-900">
+                    {directCards}개
+                  </p>
+                </div>
               </div>
             </div>
-          </div>
-        </header>
+          </header>
 
-        {isBloodlineLoading ? (
-          <div className="flex h-20 items-center justify-center">
-            <Spinner />
-          </div>
-        ) : (
-          <>
-            {renderSection("myBloodlines", myBloodlines)}
-            {renderSection("createdLines", createdLines)}
-            {renderSection("receivedCards", receivedCards)}
-          </>
-        )}
+          {isBloodlineLoading ? (
+            <div className="flex h-20 items-center justify-center">
+              <Spinner />
+            </div>
+          ) : (
+            <>
+              {renderSection("myBloodlines", myBloodlines)}
+              {renderSection("createdLines", createdLines)}
+              {renderSection("receivedCards", receivedCards)}
+            </>
+          )}
+        </div>
       </div>
-    </div>
+    </Layout>
   );
 }

--- a/app/(web)/bloodline-management/_components/BloodlineManagementEventsClient.tsx
+++ b/app/(web)/bloodline-management/_components/BloodlineManagementEventsClient.tsx
@@ -4,11 +4,12 @@ import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import useSWR from "swr";
 import { Spinner } from "@components/atoms/Spinner";
+import Layout from "@components/features/MainLayout";
 import useUser from "hooks/useUser";
 import {
- BloodlineCardEventsResponse,
- BloodlineCardItem,
- BloodlineCardsResponse,
+  BloodlineCardEventsResponse,
+  BloodlineCardItem,
+  BloodlineCardsResponse,
 } from "@libs/shared/bloodline-card";
 
 const actionLabel: Record<string, string> = {
@@ -21,150 +22,179 @@ const actionLabel: Record<string, string> = {
 };
 
 const headerButtonClass =
- "inline-flex h-9 items-center justify-center rounded-none bg-white px-3 text-sm font-medium text-slate-700 transition hover:bg-slate-50";
+  "inline-flex h-9 items-center justify-center rounded-none bg-white px-3 text-sm font-medium text-slate-700 transition hover:bg-slate-50";
 const detailLinkClass =
- "mt-2 inline-flex h-8 items-center justify-center rounded-none bg-slate-50 px-3 text-xs font-medium text-slate-700 transition hover:bg-slate-100";
+  "mt-2 inline-flex h-8 items-center justify-center rounded-none bg-slate-50 px-3 text-xs font-medium text-slate-700 transition hover:bg-slate-100";
 
 export default function BloodlineManagementEventsClient() {
- const { user } = useUser();
- const { data: bloodlineData, isLoading: isBloodlineLoading } = useSWR<BloodlineCardsResponse>(
- user?.id ? "/api/bloodline-cards" : null
- );
+  const { user } = useUser();
+  const { data: bloodlineData, isLoading: isBloodlineLoading } =
+    useSWR<BloodlineCardsResponse>(user?.id ? "/api/bloodline-cards" : null);
 
- const [events, setEvents] = useState<BloodlineCardEventsResponse["events"]>([]);
- const [query, setQuery] = useState("");
+  const [events, setEvents] = useState<BloodlineCardEventsResponse["events"]>(
+    [],
+  );
+  const [query, setQuery] = useState("");
 
- const cards = useMemo<BloodlineCardItem[]>(() => {
- if (!bloodlineData) return [];
+  const cards = useMemo<BloodlineCardItem[]>(() => {
+    if (!bloodlineData) return [];
 
- const allCards = [
- ...(bloodlineData.myBloodlines || []),
- ...(bloodlineData.createdLines || []),
- ...(bloodlineData.receivedBloodlines || []),
- ...(bloodlineData.receivedLines || []),
- ];
+    const allCards = [
+      ...(bloodlineData.myBloodlines || []),
+      ...(bloodlineData.createdLines || []),
+      ...(bloodlineData.receivedBloodlines || []),
+      ...(bloodlineData.receivedLines || []),
+    ];
 
- if (allCards.length) {
- return allCards;
- }
+    if (allCards.length) {
+      return allCards;
+    }
 
- return bloodlineData.ownedCards || [];
- }, [bloodlineData]);
+    return bloodlineData.ownedCards || [];
+  }, [bloodlineData]);
 
- const cardIds = useMemo(() => Array.from(new Set(cards.map((card) => card.id))).slice(0, 25), [cards]);
+  const cardIds = useMemo(
+    () => Array.from(new Set(cards.map((card) => card.id))).slice(0, 25),
+    [cards],
+  );
 
- useEffect(() => {
- if (!user?.id || cardIds.length === 0) {
- setEvents([]);
- return;
- }
+  useEffect(() => {
+    if (!user?.id || cardIds.length === 0) {
+      setEvents([]);
+      return;
+    }
 
- let active = true;
+    let active = true;
 
- const load = async () => {
- const loaded = await Promise.all(
- cardIds.map((cardId) =>
- fetch(`/api/bloodline-cards/${cardId}/events?limit=10`)
- .then((response) => response.json() as Promise<BloodlineCardEventsResponse>)
- .catch(() => ({ success: false, events: [] } as BloodlineCardEventsResponse))
- )
- );
+    const load = async () => {
+      const loaded = await Promise.all(
+        cardIds.map((cardId) =>
+          fetch(`/api/bloodline-cards/${cardId}/events?limit=10`)
+            .then(
+              (response) =>
+                response.json() as Promise<BloodlineCardEventsResponse>,
+            )
+            .catch(
+              () =>
+                ({ success: false, events: [] }) as BloodlineCardEventsResponse,
+            ),
+        ),
+      );
 
- if (!active) return;
+      if (!active) return;
 
- const sorted = loaded
- .flatMap((item) => (item.success ? item.events || [] : []))
- .sort((left, right) =>
- new Date(right.createdAt).getTime() - new Date(left.createdAt).getTime()
- );
+      const sorted = loaded
+        .flatMap((item) => (item.success ? item.events || [] : []))
+        .sort(
+          (left, right) =>
+            new Date(right.createdAt).getTime() -
+            new Date(left.createdAt).getTime(),
+        );
 
- setEvents(sorted);
- };
+      setEvents(sorted);
+    };
 
- load();
+    load();
 
- return () => {
- active = false;
- };
- }, [cardIds, user?.id]);
+    return () => {
+      active = false;
+    };
+  }, [cardIds, user?.id]);
 
- const filteredEvents = useMemo(() => {
- const normalized = query.trim().toLowerCase();
- if (!normalized) return events;
- return events.filter((event) =>
- `${event.action} ${event.actorUser?.name || ""} ${event.fromUser?.name || ""} ${
- event.toUser?.name || ""
- } ${event.relatedCard?.name || ""} ${event.note || ""}`
- .toLowerCase()
- .includes(normalized)
- );
- }, [events, query]);
+  const filteredEvents = useMemo(() => {
+    const normalized = query.trim().toLowerCase();
+    if (!normalized) return events;
+    return events.filter((event) =>
+      `${event.action} ${event.actorUser?.name || ""} ${
+        event.fromUser?.name || ""
+      } ${event.toUser?.name || ""} ${event.relatedCard?.name || ""} ${
+        event.note || ""
+      }`
+        .toLowerCase()
+        .includes(normalized),
+    );
+  }, [events, query]);
 
- return (
- <section className="app-page min-h-screen pb-6">
- <div className="mx-auto flex w-full max-w-[900px] flex-col space-y-4">
- <header className="space-y-2 rounded-none bg-white p-4">
- <p className="app-kicker">BLOODLINE MANAGEMENT</p>
- <div className="mt-1 flex flex-wrap items-center justify-between gap-2">
- <div>
- <h1 className="app-title-xl">이벤트 타임라인</h1>
- <p className="app-body-sm mt-1 text-slate-600">보유 카드 기준으로 활동 이력을 통합 정렬했습니다.</p>
- </div>
- <Link
- href="/bloodline-management"
- className={headerButtonClass}
- >
- 혈통관리 돌아가기
- </Link>
- </div>
- </header>
+  return (
+    <Layout
+      canGoBack
+      hasTabBar
+      showHome
+      title="이벤트 타임라인"
+      seoTitle="혈통 이벤트"
+    >
+      <section className="px-4 py-4">
+        <div className="mx-auto flex w-full max-w-[900px] flex-col space-y-4">
+          <header className="space-y-2 rounded-none bg-white p-4">
+            <p className="app-kicker">BLOODLINE MANAGEMENT</p>
+            <div className="mt-1 flex flex-wrap items-center justify-between gap-2">
+              <div>
+                <h1 className="app-title-xl">이벤트 타임라인</h1>
+                <p className="app-body-sm mt-1 text-slate-600">
+                  보유 카드 기준으로 활동 이력을 통합 정렬했습니다.
+                </p>
+              </div>
+              <Link href="/bloodline-management" className={headerButtonClass}>
+                혈통관리 돌아가기
+              </Link>
+            </div>
+          </header>
 
- <input
- value={query}
- onChange={(event) => setQuery(event.target.value)}
- placeholder="이벤트 검색 (액션/닉네임/카드명)"
-          className="h-11 w-full rounded-none bg-white px-4 text-sm outline-none ring-0 transition focus:outline-none focus:ring-0"
- />
+          <input
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="이벤트 검색 (액션/닉네임/카드명)"
+            className="h-11 w-full rounded-none bg-white px-4 text-sm outline-none ring-0 transition focus:outline-none focus:ring-0"
+          />
 
- {isBloodlineLoading ? (
- <div className="flex h-24 items-center justify-center">
- <Spinner />
- </div>
- ) : null}
+          {isBloodlineLoading ? (
+            <div className="flex h-24 items-center justify-center">
+              <Spinner />
+            </div>
+          ) : null}
 
- {filteredEvents.length ? (
- <div className="space-y-3">
- {filteredEvents.map((event) => (
- <article key={event.id} className="rounded-none bg-white p-3">
- <div className="flex items-start justify-between gap-2">
- <div>
- <p className="text-sm font-black text-slate-900">{actionLabel[event.action] || event.action}</p>
- <p className="mt-1 text-xs text-slate-500">
- {event.actorUser?.name || "시스템"}
- {event.fromUser ? ` · ${event.fromUser.name}` : ""}
- {event.toUser ? ` → ${event.toUser.name}` : ""}
- </p>
- {event.note ? <p className="mt-1 text-xs text-slate-600">{event.note}</p> : null}
- </div>
- <span className="text-xs text-slate-500">{new Date(event.createdAt).toLocaleString("ko-KR")}</span>
- </div>
- {event.relatedCard ? (
- <Link
- href={`/bloodline-management/card/${event.relatedCard.id}`}
- className={detailLinkClass}
- >
- 카드 상세로 이동
- </Link>
- ) : null}
- </article>
- ))}
- </div>
- ) : (
- <p className="rounded-none bg-slate-50 p-4 text-sm text-slate-600">
- 표시할 이벤트가 없습니다.
- </p>
- )}
- </div>
- </section>
- );
+          {filteredEvents.length ? (
+            <div className="space-y-3">
+              {filteredEvents.map((event) => (
+                <article key={event.id} className="rounded-none bg-white p-3">
+                  <div className="flex items-start justify-between gap-2">
+                    <div>
+                      <p className="text-sm font-black text-slate-900">
+                        {actionLabel[event.action] || event.action}
+                      </p>
+                      <p className="mt-1 text-xs text-slate-500">
+                        {event.actorUser?.name || "시스템"}
+                        {event.fromUser ? ` · ${event.fromUser.name}` : ""}
+                        {event.toUser ? ` → ${event.toUser.name}` : ""}
+                      </p>
+                      {event.note ? (
+                        <p className="mt-1 text-xs text-slate-600">
+                          {event.note}
+                        </p>
+                      ) : null}
+                    </div>
+                    <span className="text-xs text-slate-500">
+                      {new Date(event.createdAt).toLocaleString("ko-KR")}
+                    </span>
+                  </div>
+                  {event.relatedCard ? (
+                    <Link
+                      href={`/bloodline-management/card/${event.relatedCard.id}`}
+                      className={detailLinkClass}
+                    >
+                      카드 상세로 이동
+                    </Link>
+                  ) : null}
+                </article>
+              ))}
+            </div>
+          ) : (
+            <p className="rounded-none bg-slate-50 p-4 text-sm text-slate-600">
+              표시할 이벤트가 없습니다.
+            </p>
+          )}
+        </div>
+      </section>
+    </Layout>
+  );
 }

--- a/app/(web)/bloodline-management/_components/BloodlineSectionListClient.tsx
+++ b/app/(web)/bloodline-management/_components/BloodlineSectionListClient.tsx
@@ -6,9 +6,13 @@ import { useRouter } from "next/navigation";
 import useSWR from "swr";
 import { Input } from "@components/ui/input";
 import { Spinner } from "@components/atoms/Spinner";
+import Layout from "@components/features/MainLayout";
 import { BloodlineVisualCard } from "@components/features/bloodline/BloodlineVisualCard";
 import useUser from "hooks/useUser";
-import { BloodlineCardsResponse, BloodlineCardItem } from "@libs/shared/bloodline-card";
+import {
+  BloodlineCardsResponse,
+  BloodlineCardItem,
+} from "@libs/shared/bloodline-card";
 
 type SectionMode = "myBloodlines" | "createdLines" | "receivedCards";
 
@@ -16,7 +20,10 @@ interface BloodlineSectionListClientProps {
   mode: SectionMode;
 }
 
-const sectionMeta: Record<SectionMode, { title: string; sub: string; backLabel: string }> = {
+const sectionMeta: Record<
+  SectionMode,
+  { title: string; sub: string; backLabel: string }
+> = {
   myBloodlines: {
     title: "내 혈통",
     sub: "원본 혈통카드",
@@ -40,13 +47,14 @@ const cardTypeClassByKind =
 const toCardMetaLabel = (card: BloodlineCardItem) =>
   card.cardType === "BLOODLINE" ? "혈통" : "라인";
 
-export default function BloodlineSectionListClient({ mode }: BloodlineSectionListClientProps) {
+export default function BloodlineSectionListClient({
+  mode,
+}: BloodlineSectionListClientProps) {
   const router = useRouter();
   const { user } = useUser();
-  const {
-    data: bloodlineData,
-    isLoading,
-  } = useSWR<BloodlineCardsResponse>(user?.id ? "/api/bloodline-cards" : null);
+  const { data: bloodlineData, isLoading } = useSWR<BloodlineCardsResponse>(
+    user?.id ? "/api/bloodline-cards" : null,
+  );
 
   const [query, setQuery] = useState("");
 
@@ -54,10 +62,12 @@ export default function BloodlineSectionListClient({ mode }: BloodlineSectionLis
     if (!bloodlineData) return [];
     if (bloodlineData.myBloodlines?.length) return bloodlineData.myBloodlines;
     if (bloodlineData.myCreatedCards?.length) {
-      return bloodlineData.myCreatedCards.filter((card) => card.cardType === "BLOODLINE");
+      return bloodlineData.myCreatedCards.filter(
+        (card) => card.cardType === "BLOODLINE",
+      );
     }
     return (bloodlineData.ownedCards || []).filter(
-      (card) => card.creator.id === user?.id && card.cardType === "BLOODLINE"
+      (card) => card.creator.id === user?.id && card.cardType === "BLOODLINE",
     );
   }, [bloodlineData, user?.id]);
 
@@ -65,21 +75,26 @@ export default function BloodlineSectionListClient({ mode }: BloodlineSectionLis
     if (!bloodlineData) return [];
     if (bloodlineData.createdLines?.length) return bloodlineData.createdLines;
     if (bloodlineData.myCreatedCards?.length) {
-      return bloodlineData.myCreatedCards.filter((card) => card.cardType === "LINE");
+      return bloodlineData.myCreatedCards.filter(
+        (card) => card.cardType === "LINE",
+      );
     }
     return (bloodlineData.ownedCards || []).filter(
-      (card) => card.creator.id === user?.id && card.cardType === "LINE"
+      (card) => card.creator.id === user?.id && card.cardType === "LINE",
     );
   }, [bloodlineData, user?.id]);
 
   const receivedBloodlines = useMemo(() => {
     if (!bloodlineData) return [];
-    if (bloodlineData.receivedBloodlines?.length) return bloodlineData.receivedBloodlines;
+    if (bloodlineData.receivedBloodlines?.length)
+      return bloodlineData.receivedBloodlines;
     if (bloodlineData.receivedCards?.length) {
-      return bloodlineData.receivedCards.filter((card) => card.cardType === "BLOODLINE");
+      return bloodlineData.receivedCards.filter(
+        (card) => card.cardType === "BLOODLINE",
+      );
     }
     return (bloodlineData.ownedCards || []).filter(
-      (card) => card.creator.id !== user?.id && card.cardType === "BLOODLINE"
+      (card) => card.creator.id !== user?.id && card.cardType === "BLOODLINE",
     );
   }, [bloodlineData, user?.id]);
 
@@ -87,10 +102,12 @@ export default function BloodlineSectionListClient({ mode }: BloodlineSectionLis
     if (!bloodlineData) return [];
     if (bloodlineData.receivedLines?.length) return bloodlineData.receivedLines;
     if (bloodlineData.receivedCards?.length) {
-      return bloodlineData.receivedCards.filter((card) => card.cardType === "LINE");
+      return bloodlineData.receivedCards.filter(
+        (card) => card.cardType === "LINE",
+      );
     }
     return (bloodlineData.ownedCards || []).filter(
-      (card) => card.creator.id !== user?.id && card.cardType === "LINE"
+      (card) => card.creator.id !== user?.id && card.cardType === "LINE",
     );
   }, [bloodlineData, user?.id]);
 
@@ -119,94 +136,113 @@ export default function BloodlineSectionListClient({ mode }: BloodlineSectionLis
   };
 
   return (
-    <section className="app-page min-h-screen">
-      <div className="mx-auto flex w-full max-w-[680px] flex-col gap-3">
-        <header className="rounded-xl border border-slate-200 bg-white p-4">
-          <p className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">
-            BLOODLINE MANAGEMENT
-          </p>
-          <div className="mt-1 flex flex-wrap items-start justify-between gap-2">
-            <div className="min-w-0">
-              <h1 className="app-title-md">{sectionMeta[mode].title}</h1>
-              <p className="app-body-sm mt-1 text-slate-600">{sectionMeta[mode].sub}</p>
-            </div>
-            <Link
-              href="/bloodline-management"
-              className="inline-flex h-8 items-center rounded-full bg-slate-100 px-3 text-xs font-semibold text-slate-700 transition hover:bg-slate-200"
-            >
-              {sectionMeta[mode].backLabel}
-            </Link>
-          </div>
-        </header>
-
-        <Input
-          value={query}
-          onChange={(event) => setQuery(event.target.value)}
-          placeholder="카드명/닉네임 검색"
-          className="h-11 rounded-lg"
-        />
-
-        <p className="text-sm font-semibold text-slate-700">조회: {filteredCards.length}개</p>
-
-        {isLoading ? (
-          <div className="flex h-24 items-center justify-center">
-            <Spinner />
-          </div>
-        ) : filteredCards.length ? (
-          <>
-          <div className="grid grid-cols-2 gap-2">
-            {filteredCards.map((card) => (
-              <article
-                key={card.id}
-                role="button"
-                tabIndex={0}
-                onClick={() => handleCardClick(card.id)}
-                onKeyDown={(event) => {
-                  if (event.key === "Enter" || event.key === " ") {
-                    event.preventDefault();
-                    handleCardClick(card.id);
-                  }
-                }}
-                className="cursor-pointer rounded-lg border border-slate-200 bg-white p-3 transition duration-150 hover:shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-300"
+    <Layout
+      canGoBack
+      hasTabBar
+      showHome
+      title={sectionMeta[mode].title}
+      seoTitle={sectionMeta[mode].title}
+    >
+      <section className="px-4 py-4">
+        <div className="mx-auto flex w-full max-w-[680px] flex-col gap-3">
+          <header className="rounded-xl border border-slate-200 bg-white p-4">
+            <p className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">
+              BLOODLINE MANAGEMENT
+            </p>
+            <div className="mt-1 flex flex-wrap items-start justify-between gap-2">
+              <div className="min-w-0">
+                <h1 className="app-title-md">{sectionMeta[mode].title}</h1>
+                <p className="app-body-sm mt-1 text-slate-600">
+                  {sectionMeta[mode].sub}
+                </p>
+              </div>
+              <Link
+                href="/bloodline-management"
+                className="inline-flex h-8 items-center rounded-full bg-slate-100 px-3 text-xs font-semibold text-slate-700 transition hover:bg-slate-200"
               >
-                <BloodlineVisualCard
-                  cardId={card.id}
-                  name={card.name}
-                  ownerName={card.currentOwner.name}
-                  subtitle={card.description || "설명이 없습니다."}
-                  image={card.image}
-                  variant={card.visualStyle}
-                  compact
-                />
-                <div className="mt-2 space-y-1">
-                  <div className="flex items-start justify-between gap-2">
-                    <p className="line-clamp-1 text-sm font-bold text-slate-900">{card.name}</p>
-                    <span
-                      className={`${cardTypeClassByKind} ${
-                        card.cardType === "BLOODLINE"
-                          ? "bg-blue-50 text-blue-700"
-                          : "bg-emerald-50 text-emerald-700"
-                      }`}
-                    >
-                      {toCardMetaLabel(card)}
-                    </span>
-                  </div>
-                  <p className="text-xs text-slate-500">제작 {card.creator.name}</p>
-                  <p className="text-xs text-slate-500">보유 {card.currentOwner.name}</p>
-                </div>
-              </article>
-            ))}
-          </div>
-          <p className="text-xs text-slate-500">
-            카드 상세에서 보내기 또는 라인 만들기 작업을 이어서 진행할 수 있습니다.
+                {sectionMeta[mode].backLabel}
+              </Link>
+            </div>
+          </header>
+
+          <Input
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="카드명/닉네임 검색"
+            className="h-11 rounded-lg"
+          />
+
+          <p className="text-sm font-semibold text-slate-700">
+            조회: {filteredCards.length}개
           </p>
-          </>
-        ) : (
-          <p className="rounded-lg bg-slate-50 px-3 py-6 text-sm text-slate-600">
-            조회 가능한 카드가 없습니다.
-          </p>
-        )}
-      </div>
-    </section>
+
+          {isLoading ? (
+            <div className="flex h-24 items-center justify-center">
+              <Spinner />
+            </div>
+          ) : filteredCards.length ? (
+            <>
+              <div className="grid grid-cols-2 gap-2">
+                {filteredCards.map((card) => (
+                  <article
+                    key={card.id}
+                    role="button"
+                    tabIndex={0}
+                    onClick={() => handleCardClick(card.id)}
+                    onKeyDown={(event) => {
+                      if (event.key === "Enter" || event.key === " ") {
+                        event.preventDefault();
+                        handleCardClick(card.id);
+                      }
+                    }}
+                    className="cursor-pointer rounded-lg border border-slate-200 bg-white p-3 transition duration-150 hover:shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-300"
+                  >
+                    <BloodlineVisualCard
+                      cardId={card.id}
+                      name={card.name}
+                      ownerName={card.currentOwner.name}
+                      subtitle={card.description || "설명이 없습니다."}
+                      image={card.image}
+                      variant={card.visualStyle}
+                      compact
+                    />
+                    <div className="mt-2 space-y-1">
+                      <div className="flex items-start justify-between gap-2">
+                        <p className="line-clamp-1 text-sm font-bold text-slate-900">
+                          {card.name}
+                        </p>
+                        <span
+                          className={`${cardTypeClassByKind} ${
+                            card.cardType === "BLOODLINE"
+                              ? "bg-blue-50 text-blue-700"
+                              : "bg-emerald-50 text-emerald-700"
+                          }`}
+                        >
+                          {toCardMetaLabel(card)}
+                        </span>
+                      </div>
+                      <p className="text-xs text-slate-500">
+                        제작 {card.creator.name}
+                      </p>
+                      <p className="text-xs text-slate-500">
+                        보유 {card.currentOwner.name}
+                      </p>
+                    </div>
+                  </article>
+                ))}
+              </div>
+              <p className="text-xs text-slate-500">
+                카드 상세에서 보내기 또는 라인 만들기 작업을 이어서 진행할 수
+                있습니다.
+              </p>
+            </>
+          ) : (
+            <p className="rounded-lg bg-slate-50 px-3 py-6 text-sm text-slate-600">
+              조회 가능한 카드가 없습니다.
+            </p>
+          )}
+        </div>
+      </section>
+    </Layout>
   );
 }

--- a/app/(web)/bloodline-management/card/[cardId]/BloodlineCardDetailClient.tsx
+++ b/app/(web)/bloodline-management/card/[cardId]/BloodlineCardDetailClient.tsx
@@ -7,6 +7,7 @@ import useSWR from "swr";
 import { Button } from "@components/ui/button";
 import { Input } from "@components/ui/input";
 import { Spinner } from "@components/atoms/Spinner";
+import Layout from "@components/features/MainLayout";
 import useUser from "hooks/useUser";
 import {
   BloodlineCardDetailResponse,
@@ -395,9 +396,11 @@ export default function BloodlineCardDetailClient({
 
   if (isLoading) {
     return (
-      <div className="app-page flex min-h-screen items-center justify-center">
-        <Spinner />
-      </div>
+      <Layout canGoBack hasTabBar showHome title="혈통카드" seoTitle="혈통카드">
+        <div className="flex min-h-[60vh] items-center justify-center px-4 py-4">
+          <Spinner />
+        </div>
+      </Layout>
     );
   }
 
@@ -405,380 +408,403 @@ export default function BloodlineCardDetailClient({
     const isWaitingForSync = missingCardRetryCount < 2;
     if (isWaitingForSync) {
       return (
-        <div className="app-page flex min-h-screen items-center justify-center">
-          <div className="rounded-xl border border-slate-200 bg-white px-4 py-4 text-sm text-slate-700 shadow-sm">
-            <Spinner />
-            <p className="mt-2">카드 정보를 불러오는 중입니다.</p>
+        <Layout
+          canGoBack
+          hasTabBar
+          showHome
+          title="혈통카드"
+          seoTitle="혈통카드"
+        >
+          <div className="flex min-h-[60vh] items-center justify-center px-4 py-4">
+            <div className="rounded-xl border border-slate-200 bg-white px-4 py-4 text-sm text-slate-700 shadow-sm">
+              <Spinner />
+              <p className="mt-2">카드 정보를 불러오는 중입니다.</p>
+            </div>
           </div>
-        </div>
+        </Layout>
       );
     }
 
     return (
-      <section className="app-page">
-        <div className="mx-auto w-full max-w-[680px] rounded-xl border border-slate-200 bg-white p-5">
-          <h1 className="text-lg font-black text-slate-900">
-            카드를 찾을 수 없습니다.
-          </h1>
-          <p className="mt-1 text-sm text-slate-600">
-            카드 ID가 없거나 비활성화된 카드일 수 있습니다.
-          </p>
-          <Link
-            href="/bloodline-management"
-            className="mt-4 inline-flex h-10 items-center justify-center rounded-lg bg-slate-900 px-4 text-sm font-medium text-white transition hover:bg-slate-800"
-          >
-            혈통관리로 이동
-          </Link>
-        </div>
-      </section>
+      <Layout canGoBack hasTabBar showHome title="혈통카드" seoTitle="혈통카드">
+        <section className="px-4 py-4">
+          <div className="mx-auto w-full max-w-[680px] rounded-xl border border-slate-200 bg-white p-5">
+            <h1 className="text-lg font-black text-slate-900">
+              카드를 찾을 수 없습니다.
+            </h1>
+            <p className="mt-1 text-sm text-slate-600">
+              카드 ID가 없거나 비활성화된 카드일 수 있습니다.
+            </p>
+            <Link
+              href="/bloodline-management"
+              className="mt-4 inline-flex h-10 items-center justify-center rounded-lg bg-slate-900 px-4 text-sm font-medium text-white transition hover:bg-slate-800"
+            >
+              혈통관리로 이동
+            </Link>
+          </div>
+        </section>
+      </Layout>
     );
   }
 
   return (
-    <section className="app-page min-h-screen">
-      <div className="mx-auto flex w-full max-w-[680px] flex-col gap-3">
-        {showCelebrationModal ? (
-          <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/55 px-4">
-            <div className="relative w-full max-w-sm rounded-lg border border-slate-200 bg-white p-5 shadow-xl">
-              <div className="relative text-center">
-                <p className="text-sm font-bold text-slate-900">
-                  {celebrationCardName
-                    ? `"${celebrationCardName}"`
-                    : "혈통카드"}
-                  가 완성됐습니다!
-                </p>
-                <p className="mt-2 text-sm leading-relaxed text-slate-500">
-                  화면을 캡쳐해서 친구들에게 공유해보세요.
-                </p>
-                <Button
-                  type="button"
-                  className="mt-5 h-11 w-full rounded-lg bg-slate-900 text-sm font-semibold text-white hover:bg-slate-800"
-                  onClick={handleCloseCelebrationModal}
-                >
-                  닫기
-                </Button>
+    <Layout
+      canGoBack
+      hasTabBar
+      showHome
+      title={isBloodline ? "혈통카드" : "라인카드"}
+      seoTitle={card.name}
+    >
+      <section className="px-4 py-4">
+        <div className="mx-auto flex w-full max-w-[680px] flex-col gap-3">
+          {showCelebrationModal ? (
+            <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/55 px-4">
+              <div className="relative w-full max-w-sm rounded-lg border border-slate-200 bg-white p-5 shadow-xl">
+                <div className="relative text-center">
+                  <p className="text-sm font-bold text-slate-900">
+                    {celebrationCardName
+                      ? `"${celebrationCardName}"`
+                      : "혈통카드"}
+                    가 완성됐습니다!
+                  </p>
+                  <p className="mt-2 text-sm leading-relaxed text-slate-500">
+                    화면을 캡쳐해서 친구들에게 공유해보세요.
+                  </p>
+                  <Button
+                    type="button"
+                    className="mt-5 h-11 w-full rounded-lg bg-slate-900 text-sm font-semibold text-white hover:bg-slate-800"
+                    onClick={handleCloseCelebrationModal}
+                  >
+                    닫기
+                  </Button>
+                </div>
               </div>
             </div>
-          </div>
-        ) : null}
-        <div className={sectionClass}>
-          <div className={panelHeaderClass}>
-            <Link
-              href="/bloodline-management"
-              className="inline-flex h-8 items-center justify-center rounded-lg border border-slate-200 bg-white px-3 text-xs font-medium text-slate-700 transition hover:bg-slate-50"
-            >
-              목록으로
-            </Link>
-            <span className="rounded-md bg-slate-100 px-2.5 py-1 text-[11px] font-semibold text-slate-700">
-              {isBloodline ? "혈통카드" : "라인카드"}
-            </span>
-          </div>
-
-          <h1 className="app-title-lg text-slate-900">{card.name}</h1>
-          <p className="mt-1.5 text-sm leading-relaxed text-slate-600">
-            {card.description || "설명이 없습니다."}
-          </p>
-
-          <div className="mt-3 flex flex-wrap gap-2">
-            <span className={chipClass}>현재 상태 {card.status}</span>
-            <span className={chipClass}>발급 {card.transfers.length}회</span>
-            <span className={chipClass}>ID #{card.id}</span>
-          </div>
-          {lineageTransferHint ? (
-            <p className="mt-2 inline-flex rounded-md bg-amber-50 px-3 py-1 text-xs text-amber-700">
-              {lineageTransferHint}
-            </p>
           ) : null}
-        </div>
-
-        <article className={sectionClass}>
-          <div className={panelHeaderClass}>
-            <h2 className="text-sm font-bold text-slate-900">카드 미리보기</h2>
-          </div>
-          <BloodlineVisualCard
-            cardId={card.id}
-            name={card.name}
-            ownerName={card.currentOwner.name}
-            subtitle={card.description || "설명이 없습니다."}
-            image={card.image}
-            variant={card.visualStyle}
-          />
-        </article>
-
-        <article className={sectionClass}>
-          <div className={panelHeaderClass}>
-            <h2 className="text-sm font-bold text-slate-900">기본 정보</h2>
-          </div>
-          <div className="grid gap-2">
-            <p className={chipClass}>
-              제작자:{" "}
+          <div className={sectionClass}>
+            <div className={panelHeaderClass}>
               <Link
-                href={`/profiles/${card.creator.id}`}
-                className="font-semibold text-slate-900 underline underline-offset-4"
+                href="/bloodline-management"
+                className="inline-flex h-8 items-center justify-center rounded-lg border border-slate-200 bg-white px-3 text-xs font-medium text-slate-700 transition hover:bg-slate-50"
               >
-                {card.creator.name}
+                목록으로
               </Link>
+              <span className="rounded-md bg-slate-100 px-2.5 py-1 text-[11px] font-semibold text-slate-700">
+                {isBloodline ? "혈통카드" : "라인카드"}
+              </span>
+            </div>
+
+            <h1 className="app-title-lg text-slate-900">{card.name}</h1>
+            <p className="mt-1.5 text-sm leading-relaxed text-slate-600">
+              {card.description || "설명이 없습니다."}
             </p>
-            <p className={chipClass}>
-              현재 보유자:{" "}
-              <Link
-                href={`/profiles/${card.currentOwner.id}`}
-                className="font-semibold text-slate-900 underline underline-offset-4"
-              >
-                {card.currentOwner.name}
-              </Link>
-            </p>
-            {card.cardType === "LINE" ? (
-              <>
-                <div className={chipClass}>
-                  원본 혈통:{" "}
-                  {bloodlineSourceCard ? (
-                    <Link
-                      href={`/bloodline-management/card/${bloodlineSourceCard.id}`}
-                      className="font-semibold text-slate-900 underline underline-offset-4"
-                    >
-                      #{bloodlineSourceCard.id} {bloodlineSourceCard.name}
-                    </Link>
-                  ) : (
-                    `#${card.bloodlineReferenceId}`
-                  )}
-                </div>
-                <div className={chipClass}>
-                  상위 라인:{" "}
-                  {parentLineCard ? (
-                    <Link
-                      href={`/bloodline-management/card/${parentLineCard.id}`}
-                      className="font-semibold text-slate-900 underline underline-offset-4"
-                    >
-                      #{parentLineCard.id} {parentLineCard.name}
-                    </Link>
-                  ) : card.parentCardId ? (
-                    `#${card.parentCardId}`
-                  ) : (
-                    "직접 파생 없음"
-                  )}
-                </div>
-              </>
+
+            <div className="mt-3 flex flex-wrap gap-2">
+              <span className={chipClass}>현재 상태 {card.status}</span>
+              <span className={chipClass}>발급 {card.transfers.length}회</span>
+              <span className={chipClass}>ID #{card.id}</span>
+            </div>
+            {lineageTransferHint ? (
+              <p className="mt-2 inline-flex rounded-md bg-amber-50 px-3 py-1 text-xs text-amber-700">
+                {lineageTransferHint}
+              </p>
             ) : null}
           </div>
-        </article>
 
-        <article className={sectionClass}>
-          <div className={panelHeaderClass}>
-            <h2 className="text-sm font-bold text-slate-900">
-              {canTransfer || canIssue ? "카드 발급/전송" : "열람 정보"}
-            </h2>
-          </div>
+          <article className={sectionClass}>
+            <div className={panelHeaderClass}>
+              <h2 className="text-sm font-bold text-slate-900">
+                카드 미리보기
+              </h2>
+            </div>
+            <BloodlineVisualCard
+              cardId={card.id}
+              name={card.name}
+              ownerName={card.currentOwner.name}
+              subtitle={card.description || "설명이 없습니다."}
+              image={card.image}
+              variant={card.visualStyle}
+            />
+          </article>
 
-          {canTransfer || canIssue ? (
-            <div className="space-y-2">
-              {error ? (
-                <p className="rounded-lg border border-rose-200 bg-rose-50 px-3 py-2 text-sm font-medium text-rose-700">
-                  {error}
-                </p>
+          <article className={sectionClass}>
+            <div className={panelHeaderClass}>
+              <h2 className="text-sm font-bold text-slate-900">기본 정보</h2>
+            </div>
+            <div className="grid gap-2">
+              <p className={chipClass}>
+                제작자:{" "}
+                <Link
+                  href={`/profiles/${card.creator.id}`}
+                  className="font-semibold text-slate-900 underline underline-offset-4"
+                >
+                  {card.creator.name}
+                </Link>
+              </p>
+              <p className={chipClass}>
+                현재 보유자:{" "}
+                <Link
+                  href={`/profiles/${card.currentOwner.id}`}
+                  className="font-semibold text-slate-900 underline underline-offset-4"
+                >
+                  {card.currentOwner.name}
+                </Link>
+              </p>
+              {card.cardType === "LINE" ? (
+                <>
+                  <div className={chipClass}>
+                    원본 혈통:{" "}
+                    {bloodlineSourceCard ? (
+                      <Link
+                        href={`/bloodline-management/card/${bloodlineSourceCard.id}`}
+                        className="font-semibold text-slate-900 underline underline-offset-4"
+                      >
+                        #{bloodlineSourceCard.id} {bloodlineSourceCard.name}
+                      </Link>
+                    ) : (
+                      `#${card.bloodlineReferenceId}`
+                    )}
+                  </div>
+                  <div className={chipClass}>
+                    상위 라인:{" "}
+                    {parentLineCard ? (
+                      <Link
+                        href={`/bloodline-management/card/${parentLineCard.id}`}
+                        className="font-semibold text-slate-900 underline underline-offset-4"
+                      >
+                        #{parentLineCard.id} {parentLineCard.name}
+                      </Link>
+                    ) : card.parentCardId ? (
+                      `#${card.parentCardId}`
+                    ) : (
+                      "직접 파생 없음"
+                    )}
+                  </div>
+                </>
               ) : null}
-              {message ? (
-                <p className="rounded-lg border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm font-medium text-emerald-700">
-                  {message}
-                </p>
-              ) : null}
-              {activeAction === "transfer" ? (
-                <form className="space-y-2" onSubmit={handleTransferSubmit}>
-                  <div className="relative">
+            </div>
+          </article>
+
+          <article className={sectionClass}>
+            <div className={panelHeaderClass}>
+              <h2 className="text-sm font-bold text-slate-900">
+                {canTransfer || canIssue ? "카드 발급/전송" : "열람 정보"}
+              </h2>
+            </div>
+
+            {canTransfer || canIssue ? (
+              <div className="space-y-2">
+                {error ? (
+                  <p className="rounded-lg border border-rose-200 bg-rose-50 px-3 py-2 text-sm font-medium text-rose-700">
+                    {error}
+                  </p>
+                ) : null}
+                {message ? (
+                  <p className="rounded-lg border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm font-medium text-emerald-700">
+                    {message}
+                  </p>
+                ) : null}
+                {activeAction === "transfer" ? (
+                  <form className="space-y-2" onSubmit={handleTransferSubmit}>
+                    <div className="relative">
+                      <Input
+                        value={transferDraft[card.id]?.toUserName || ""}
+                        onChange={(event) =>
+                          setTransferDraft((prev) => ({
+                            ...prev,
+                            [card.id]: {
+                              ...prev[card.id],
+                              toUserName: event.target.value,
+                              toUserId: undefined,
+                            },
+                          }))
+                        }
+                        placeholder="보내는 상대 닉네임(필수)"
+                        className="h-11 rounded-lg"
+                      />
+                      {transferSearchLoading ||
+                      transferCandidates.length > 0 ? (
+                        <div className="absolute left-0 right-0 z-20 mt-1 max-h-56 overflow-y-auto rounded-lg border border-slate-200 bg-white shadow-md">
+                          {transferSearchLoading ? (
+                            <p className="px-3 py-2 text-sm text-slate-500">
+                              검색 중...
+                            </p>
+                          ) : transferCandidates.length ? (
+                            transferCandidates.map((item) => (
+                              <button
+                                key={item.id}
+                                type="button"
+                                onClick={() =>
+                                  handleTransferCandidateSelect(item)
+                                }
+                                className="w-full px-3 py-2 text-left text-sm text-slate-900 transition hover:bg-slate-50"
+                              >
+                                {item.name}
+                              </button>
+                            ))
+                          ) : null}
+                        </div>
+                      ) : null}
+                    </div>
                     <Input
-                      value={transferDraft[card.id]?.toUserName || ""}
+                      value={transferDraft[card.id]?.note || ""}
                       onChange={(event) =>
                         setTransferDraft((prev) => ({
                           ...prev,
                           [card.id]: {
                             ...prev[card.id],
-                            toUserName: event.target.value,
-                            toUserId: undefined,
+                            note: event.target.value,
                           },
                         }))
                       }
-                      placeholder="보내는 상대 닉네임(필수)"
+                      placeholder="메모 (선택)"
                       className="h-11 rounded-lg"
                     />
-                    {transferSearchLoading || transferCandidates.length > 0 ? (
-                      <div className="absolute left-0 right-0 z-20 mt-1 max-h-56 overflow-y-auto rounded-lg border border-slate-200 bg-white shadow-md">
-                        {transferSearchLoading ? (
-                          <p className="px-3 py-2 text-sm text-slate-500">
-                            검색 중...
-                          </p>
-                        ) : transferCandidates.length ? (
-                          transferCandidates.map((item) => (
-                            <button
-                              key={item.id}
-                              type="button"
-                              onClick={() =>
-                                handleTransferCandidateSelect(item)
-                              }
-                              className="w-full px-3 py-2 text-left text-sm text-slate-900 transition hover:bg-slate-50"
-                            >
-                              {item.name}
-                            </button>
-                          ))
-                        ) : null}
-                      </div>
+                    <div className="grid gap-2">
+                      <Button
+                        type="submit"
+                        className={actionButtonClass}
+                        disabled={transferLoading}
+                      >
+                        {transferLoading ? "처리 중..." : "확인"}
+                      </Button>
+                      <Button
+                        type="button"
+                        className={cancelButtonClass}
+                        onClick={() => setActiveAction(null)}
+                        disabled={transferLoading}
+                      >
+                        취소
+                      </Button>
+                    </div>
+                  </form>
+                ) : activeAction === "issue" ? (
+                  <form className="space-y-2" onSubmit={handleIssueSubmit}>
+                    <Input
+                      value={issueDraft[card.id]?.lineName || ""}
+                      onChange={(event) =>
+                        setIssueDraft((prev) => ({
+                          ...prev,
+                          [card.id]: {
+                            ...prev[card.id],
+                            lineName: event.target.value,
+                          },
+                        }))
+                      }
+                      placeholder="라인 이름(선택)"
+                      className="h-11 rounded-lg"
+                    />
+                    <div className="grid gap-2">
+                      <Button
+                        type="submit"
+                        className={accentButtonClass}
+                        disabled={issueLoading}
+                      >
+                        {issueLoading ? "처리 중..." : "확인"}
+                      </Button>
+                      <Button
+                        type="button"
+                        className={cancelButtonClass}
+                        onClick={() => setActiveAction(null)}
+                        disabled={issueLoading}
+                      >
+                        취소
+                      </Button>
+                    </div>
+                  </form>
+                ) : (
+                  <div className="grid gap-2">
+                    {canTransfer ? (
+                      <Button
+                        type="button"
+                        className={actionButtonClass}
+                        onClick={() => setActiveAction("transfer")}
+                      >
+                        보내기
+                      </Button>
+                    ) : null}
+                    {canIssue ? (
+                      <Button
+                        type="button"
+                        className={accentButtonClass}
+                        onClick={() => setActiveAction("issue")}
+                      >
+                        라인 만들기
+                      </Button>
                     ) : null}
                   </div>
-                  <Input
-                    value={transferDraft[card.id]?.note || ""}
-                    onChange={(event) =>
-                      setTransferDraft((prev) => ({
-                        ...prev,
-                        [card.id]: {
-                          ...prev[card.id],
-                          note: event.target.value,
-                        },
-                      }))
-                    }
-                    placeholder="메모 (선택)"
-                    className="h-11 rounded-lg"
-                  />
-                  <div className="grid gap-2">
-                    <Button
-                      type="submit"
-                      className={actionButtonClass}
-                      disabled={transferLoading}
-                    >
-                      {transferLoading ? "처리 중..." : "확인"}
-                    </Button>
-                    <Button
-                      type="button"
-                      className={cancelButtonClass}
-                      onClick={() => setActiveAction(null)}
-                      disabled={transferLoading}
-                    >
-                      취소
-                    </Button>
-                  </div>
-                </form>
-              ) : activeAction === "issue" ? (
-                <form className="space-y-2" onSubmit={handleIssueSubmit}>
-                  <Input
-                    value={issueDraft[card.id]?.lineName || ""}
-                    onChange={(event) =>
-                      setIssueDraft((prev) => ({
-                        ...prev,
-                        [card.id]: {
-                          ...prev[card.id],
-                          lineName: event.target.value,
-                        },
-                      }))
-                    }
-                    placeholder="라인 이름(선택)"
-                    className="h-11 rounded-lg"
-                  />
-                  <div className="grid gap-2">
-                    <Button
-                      type="submit"
-                      className={accentButtonClass}
-                      disabled={issueLoading}
-                    >
-                      {issueLoading ? "처리 중..." : "확인"}
-                    </Button>
-                    <Button
-                      type="button"
-                      className={cancelButtonClass}
-                      onClick={() => setActiveAction(null)}
-                      disabled={issueLoading}
-                    >
-                      취소
-                    </Button>
-                  </div>
-                </form>
-              ) : (
-                <div className="grid gap-2">
-                  {canTransfer ? (
-                    <Button
-                      type="button"
-                      className={actionButtonClass}
-                      onClick={() => setActiveAction("transfer")}
-                    >
-                      보내기
-                    </Button>
-                  ) : null}
-                  {canIssue ? (
-                    <Button
-                      type="button"
-                      className={accentButtonClass}
-                      onClick={() => setActiveAction("issue")}
-                    >
-                      라인 만들기
-                    </Button>
-                  ) : null}
-                </div>
-              )}
-            </div>
-          ) : (
-            <div className="rounded-lg border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-600">
-              <p className="font-medium text-slate-800">
-                이 카드는 현재 {card.currentOwner.name}님이 보유 중입니다.
-              </p>
-              <p className="mt-1 leading-relaxed">
-                상세 정보와 기록은 열람할 수 있고, 보내기나 라인 만들기는
-                보유자만 진행할 수 있습니다.
-              </p>
-            </div>
-          )}
-        </article>
+                )}
+              </div>
+            ) : (
+              <div className="rounded-lg border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-600">
+                <p className="font-medium text-slate-800">
+                  이 카드는 현재 {card.currentOwner.name}님이 보유 중입니다.
+                </p>
+                <p className="mt-1 leading-relaxed">
+                  상세 정보와 기록은 열람할 수 있고, 보내기나 라인 만들기는
+                  보유자만 진행할 수 있습니다.
+                </p>
+              </div>
+            )}
+          </article>
 
-        <article className={sectionClass}>
-          <div className={panelHeaderClass}>
-            <h2 className="text-sm font-bold text-slate-900">최근 기록</h2>
-            <span className="text-xs text-slate-500">총 {events.length}건</span>
-          </div>
-
-          {eventsLoading ? (
-            <div className="flex h-16 items-center justify-center">
-              <Spinner />
+          <article className={sectionClass}>
+            <div className={panelHeaderClass}>
+              <h2 className="text-sm font-bold text-slate-900">최근 기록</h2>
+              <span className="text-xs text-slate-500">
+                총 {events.length}건
+              </span>
             </div>
-          ) : events.length ? (
-            <div className="space-y-2">
-              {events.slice(0, 5).map((record) => (
-                <div
-                  key={record.id}
-                  className={`rounded-lg border p-3 ${
-                    eventToneByAction[record.action] ||
-                    "border-slate-200 bg-slate-50"
-                  } text-sm`}
-                >
-                  <div className="flex items-start justify-between gap-2">
-                    <p className="font-semibold text-slate-900">
-                      {actionLabel[record.action] || record.action}
+
+            {eventsLoading ? (
+              <div className="flex h-16 items-center justify-center">
+                <Spinner />
+              </div>
+            ) : events.length ? (
+              <div className="space-y-2">
+                {events.slice(0, 5).map((record) => (
+                  <div
+                    key={record.id}
+                    className={`rounded-lg border p-3 ${
+                      eventToneByAction[record.action] ||
+                      "border-slate-200 bg-slate-50"
+                    } text-sm`}
+                  >
+                    <div className="flex items-start justify-between gap-2">
+                      <p className="font-semibold text-slate-900">
+                        {actionLabel[record.action] || record.action}
+                      </p>
+                      <span className="text-[10px] font-semibold text-slate-700">
+                        {record.action}
+                      </span>
+                    </div>
+                    <p className="mt-1 text-xs text-slate-700">
+                      {record.actorUser?.name || "시스템"}
+                      {record.fromUser
+                        ? ` · ${record.fromUser.name} → ${
+                            record.toUser?.name || "시스템"
+                          }`
+                        : ""}
                     </p>
-                    <span className="text-[10px] font-semibold text-slate-700">
-                      {record.action}
-                    </span>
-                  </div>
-                  <p className="mt-1 text-xs text-slate-700">
-                    {record.actorUser?.name || "시스템"}
-                    {record.fromUser
-                      ? ` · ${record.fromUser.name} → ${
-                          record.toUser?.name || "시스템"
-                        }`
-                      : ""}
-                  </p>
-                  {record.note ? (
+                    {record.note ? (
+                      <p className="mt-1 text-xs text-slate-500">
+                        메모: {record.note}
+                      </p>
+                    ) : null}
                     <p className="mt-1 text-xs text-slate-500">
-                      메모: {record.note}
+                      {formatDate(record.createdAt)}
                     </p>
-                  ) : null}
-                  <p className="mt-1 text-xs text-slate-500">
-                    {formatDate(record.createdAt)}
-                  </p>
-                </div>
-              ))}
-            </div>
-          ) : (
-            <p className="rounded-lg border border-slate-200 bg-slate-50 p-3 text-sm text-slate-600">
-              기록이 없습니다.
-            </p>
-          )}
-        </article>
-      </div>
-    </section>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <p className="rounded-lg border border-slate-200 bg-slate-50 p-3 text-sm text-slate-600">
+                기록이 없습니다.
+              </p>
+            )}
+          </article>
+        </div>
+      </section>
+    </Layout>
   );
 }

--- a/app/(web)/content/breeder-program/BreederProgramClient.tsx
+++ b/app/(web)/content/breeder-program/BreederProgramClient.tsx
@@ -5,36 +5,55 @@ import Link from "next/link";
 import Layout from "@components/features/MainLayout";
 import { FOUNDING_BREEDER_LIMIT } from "@libs/shared/breeder-program";
 
-const PROGRAM_CARDS = [
+const HERO_POINTS = [
+  { value: "0원", label: "경매 수수료" },
+  { value: "전용", label: "프로필 프레임" },
+  { value: "배지", label: "등급 노출" },
+];
+
+const PROFILE_FEATURES = [
+  {
+    title: "프레임",
+    description: "프로필 사진 주변에 브리더 등급별 전용 프레임이 표시됩니다.",
+  },
+  {
+    title: "배지",
+    description:
+      "이름 아래에서 창립·파트너·인증 브리더 여부를 바로 확인할 수 있습니다.",
+  },
+  {
+    title: "혜택",
+    description: "창립 브리더는 경매 수수료 혜택까지 계정에 함께 연결됩니다.",
+  },
+];
+
+const PROGRAM_TIERS = [
   {
     title: "창립 브리더",
-    summary: "출시 후 신규 가입 선착순 100명 자동 부여",
-    badge: "평생 경매 수수료 무료",
-    frame: "골드 프레임",
-    panel: "border-orange-100 bg-orange-50/40",
-    kicker: "text-orange-700",
-    chip: "border-orange-100 bg-white text-orange-700",
-    text: "창립 멤버만 받을 수 있는 가장 높은 프레스티지 자격입니다.",
+    label: "신규 가입 선착순",
+    benefit: "평생 경매 수수료 무료",
+    description: "처음 100명에게만 자동 부여되는 초기 멤버십입니다.",
+    markerClassName: "bg-primary",
+    panelClassName: "border-primary/20 bg-primary/5",
+    labelClassName: "bg-white text-primary",
   },
   {
     title: "파트너 브리더",
-    summary: "DM 섭외나 외부 협의를 거쳐 어드민에서 수동 설정",
-    badge: "협업 할인",
-    frame: "프리미엄 프레임",
-    panel: "border-blue-100 bg-blue-50/40",
-    kicker: "text-blue-700",
-    chip: "border-blue-100 bg-white text-blue-700",
-    text: "브랜드/브리더 협업용 등급으로, 개별 할인율을 운영자가 지정합니다.",
+    label: "운영팀 선정",
+    benefit: "협업 할인 혜택",
+    description: "외부 협의나 브랜드 협업이 필요한 브리더에게 수동 부여됩니다.",
+    markerClassName: "bg-slate-900",
+    panelClassName: "border-slate-200 bg-white",
+    labelClassName: "bg-slate-100 text-slate-700",
   },
   {
     title: "인증 브리더",
-    summary: "나중에 본인 인증 플로우가 생기면 부여",
-    badge: "신뢰 배지",
-    frame: "실버 프레임",
-    panel: "border-slate-200 bg-slate-50",
-    kicker: "text-slate-600",
-    chip: "border-slate-200 bg-white text-slate-700",
-    text: "본인 인증 기반의 신뢰 등급으로, 프로필 신뢰도를 올려줍니다.",
+    label: "인증 플로우 예정",
+    benefit: "신뢰 배지 제공",
+    description: "본인 인증 기반으로 프로필 신뢰도를 높이는 등급입니다.",
+    markerClassName: "bg-slate-400",
+    panelClassName: "border-slate-200 bg-white",
+    labelClassName: "bg-slate-100 text-slate-700",
   },
 ];
 
@@ -50,130 +69,257 @@ const BreederProgramClient = ({
     ? Math.max(0, FOUNDING_BREEDER_LIMIT - foundingBreederCount)
     : null;
   const isSoldOut = remainingSlots === 0;
+  const selectedFoundingCount = foundingBreederCount ?? 0;
+  const foundingStatusLabel = hasFoundingBreederCount
+    ? isSoldOut
+      ? "창립 브리더 100인 마감"
+      : `창립 브리더 잔여 ${remainingSlots}석`
+    : "창립 브리더 현황 집계 중";
+  const foundingCountLabel = hasFoundingBreederCount
+    ? `${selectedFoundingCount}/${FOUNDING_BREEDER_LIMIT}`
+    : "--/100";
+  const remainingSlotLabel = hasFoundingBreederCount
+    ? isSoldOut
+      ? "마감"
+      : `${remainingSlots}석`
+    : "집계 중";
+  const foundingProgressPercent = hasFoundingBreederCount
+    ? Math.min(
+        100,
+        Math.max(0, (selectedFoundingCount / FOUNDING_BREEDER_LIMIT) * 100),
+      )
+    : 0;
 
   return (
     <Layout canGoBack title="브리더 프로그램" seoTitle="브리더 프로그램">
-      <div className="mx-auto max-w-3xl px-4 py-6">
-        <article className="overflow-hidden rounded-3xl border border-slate-200 bg-white shadow-sm">
-          <div className="relative overflow-hidden border-b border-slate-200 bg-slate-50 px-5 py-6 text-slate-950">
-            <p className="text-[11px] font-black uppercase tracking-[0.22em] text-slate-500">
-              breeder program
-            </p>
-            <h1 className="mt-2 text-2xl font-black tracking-tight">
-              브리디의 브리더 프레스티지 프로그램
-            </h1>
-            <p className="mt-2 max-w-2xl text-sm leading-relaxed text-slate-600">
-              창립 브리더 100인, 파트너 브리더, 인증 브리더를 각각 다른 방식으로
-              운영합니다. 프로필에는 프레임과 배지를 더해 신뢰와 희소성을 함께
-              보여줍니다.
-            </p>
-
-            <div className="mt-4 flex flex-wrap gap-2">
-              <span className="rounded-full border border-orange-100 bg-white px-3 py-1 text-[11px] font-semibold text-orange-700">
-                {hasFoundingBreederCount
-                  ? isSoldOut
-                    ? "창립 브리더 100인 마감"
-                    : `창립 브리더 잔여 ${remainingSlots}석`
-                  : "창립 브리더 현황 집계 중"}
-              </span>
-              <span className="rounded-full border border-slate-200 bg-white px-3 py-1 text-[11px] font-semibold text-slate-700">
-                평생 경매 수수료 무료
-              </span>
-              <span className="rounded-full border border-slate-200 bg-white px-3 py-1 text-[11px] font-semibold text-slate-700">
-                프로필 전용 프레임
-              </span>
-            </div>
-
-            <div className="mt-5 flex flex-wrap gap-3">
-              <Link
-                href="/auth/login"
-                className="inline-flex h-10 items-center justify-center rounded-full bg-slate-950 px-4 text-sm font-semibold text-white transition hover:bg-slate-800"
-              >
-                로그인하러 가기
-              </Link>
-              <Link
-                href="/support"
-                className="inline-flex h-10 items-center justify-center rounded-full border border-slate-300 bg-white px-4 text-sm font-semibold text-slate-700 transition hover:border-slate-400 hover:bg-slate-100"
-              >
-                문의 남기기
-              </Link>
-            </div>
+      <main className="tracking-normal text-slate-950">
+        <section className="bg-white px-5 pb-7 pt-6">
+          <div className="flex items-center justify-between gap-3">
+            <p className="text-xs font-bold text-primary">브리디 브리더 클럽</p>
+            <span className="rounded-md bg-slate-100 px-2 py-1 text-[11px] font-semibold text-slate-600">
+              {foundingStatusLabel}
+            </span>
           </div>
 
-          <div className="space-y-4 p-5">
-            <section className="rounded-2xl border border-slate-200 bg-slate-50 p-4">
-              <h2 className="text-base font-bold text-slate-900">
-                프로필에서 보이는 것
-              </h2>
-              <p className="mt-2 text-sm leading-relaxed text-slate-700">
-                브리더 자격이 있으면 프로필 사진에 전용 프레임이 붙고, 이름
-                아래에 전용 뱃지가 노출됩니다. 창립 브리더는 번호까지 표시해
-                희소성을 더하고, 파트너와 인증 브리더는 다른 색감으로
-                구분합니다.
-              </p>
-            </section>
+          <h1 className="mt-5 text-[30px] font-extrabold leading-[1.18] tracking-normal text-slate-950">
+            브리더라면,
+            <br />
+            프로필부터 다르게.
+          </h1>
+          <p className="mt-3 text-[15px] font-medium leading-[1.65] tracking-normal text-slate-600">
+            브리더 프로그램은 좋은 분양 이력을 더 잘 보이게 만드는 멤버십입니다.
+            처음 100명에게는 전용 프레임과 평생 경매 수수료 0원 혜택을 함께
+            제공합니다.
+          </p>
 
-            <div className="grid gap-3 md:grid-cols-3">
-              {PROGRAM_CARDS.map((card) => (
-                <section
-                  key={card.title}
-                  className={`rounded-2xl border ${card.panel} p-4`}
-                >
-                  <p
-                    className={`text-xs font-black uppercase tracking-[0.18em] ${card.kicker}`}
-                  >
-                    {card.title}
+          <div className="mt-5 grid grid-cols-3 overflow-hidden rounded-lg border border-slate-200 bg-white">
+            {HERO_POINTS.map((point) => (
+              <div
+                key={point.label}
+                className="border-r border-slate-100 px-3 py-3 text-center last:border-r-0"
+              >
+                <p className="text-[16px] font-black leading-none tracking-normal text-slate-950">
+                  {point.value}
+                </p>
+                <p className="mt-1.5 text-[10px] font-semibold leading-[1.3] tracking-normal text-slate-500">
+                  {point.label}
+                </p>
+              </div>
+            ))}
+          </div>
+
+          <div className="mt-5 flex gap-2">
+            <Link
+              href="/auth/login"
+              className="inline-flex h-11 flex-1 items-center justify-center rounded-lg bg-slate-950 px-4 text-sm font-bold text-white transition hover:bg-slate-800"
+            >
+              로그인하고 확인
+            </Link>
+            <Link
+              href="/support"
+              className="inline-flex h-11 items-center justify-center rounded-lg border border-slate-200 bg-white px-4 text-sm font-bold text-slate-700 transition hover:bg-slate-50"
+            >
+              문의
+            </Link>
+          </div>
+        </section>
+
+        <section className="px-5 pb-7">
+          <div className="overflow-hidden rounded-xl border border-slate-200 bg-slate-950 text-white shadow-sm">
+            <div className="flex items-center justify-between border-b border-white/10 px-4 py-3">
+              <span className="text-xs font-semibold text-white/70">
+                프로필 미리보기
+              </span>
+              <span className="rounded-md bg-primary px-2 py-1 text-[11px] font-bold text-white">
+                창립
+              </span>
+            </div>
+
+            <div className="px-4 py-5">
+              <div className="flex items-center gap-4">
+                <div className="grid h-[76px] w-[76px] shrink-0 place-items-center rounded-xl bg-primary p-1">
+                  <div className="grid h-full w-full place-items-center rounded-lg bg-white text-xl font-black text-slate-950">
+                    B
+                  </div>
+                </div>
+                <div className="min-w-0 flex-1">
+                  <p className="text-lg font-extrabold tracking-normal">
+                    브리디 켄넬
                   </p>
-                  <h3 className="mt-1 text-lg font-bold text-slate-900">
-                    {card.badge}
-                  </h3>
-                  <p className="mt-1 text-xs font-semibold text-slate-500">
-                    {card.summary}
-                  </p>
-                  <p className="mt-3 text-sm leading-relaxed text-slate-700">
-                    {card.text}
-                  </p>
-                  <div className="mt-4 flex flex-wrap gap-2">
-                    <span
-                      className={`rounded-full border px-2.5 py-1 text-[11px] font-semibold ${card.chip}`}
-                    >
-                      {card.frame}
+                  <div className="mt-2 flex flex-wrap gap-1.5">
+                    <span className="rounded-md bg-white px-2 py-1 text-[11px] font-bold text-slate-950">
+                      창립 브리더 No.001
+                    </span>
+                    <span className="rounded-md bg-white/10 px-2 py-1 text-[11px] font-semibold text-white/80">
+                      수수료 0원
                     </span>
                   </div>
-                </section>
-              ))}
+                </div>
+              </div>
+
+              <div className="mt-5 h-1.5 overflow-hidden rounded-sm bg-white/10">
+                <div
+                  className="h-full rounded-sm bg-primary"
+                  style={{ width: `${foundingProgressPercent}%` }}
+                />
+              </div>
+
+              <div className="mt-5 grid grid-cols-2 gap-2">
+                <div className="rounded-lg bg-white/10 px-3 py-3">
+                  <p className="text-[11px] font-semibold text-white/55">
+                    선정 현황
+                  </p>
+                  <p className="mt-1 text-xl font-black tracking-normal">
+                    {foundingCountLabel}
+                  </p>
+                </div>
+                <div className="rounded-lg bg-white/10 px-3 py-3">
+                  <p className="text-[11px] font-semibold text-white/55">
+                    남은 자리
+                  </p>
+                  <p className="mt-1 text-xl font-black tracking-normal">
+                    {remainingSlotLabel}
+                  </p>
+                </div>
+              </div>
             </div>
-
-            <section className="rounded-2xl border border-orange-100 bg-orange-50/50 p-4">
-              <p className="text-sm font-bold text-orange-900">
-                창립 브리더 100인
-              </p>
-              <p className="mt-2 text-sm leading-relaxed text-orange-800">
-                출시 이후 새로 가입한 유저 중 처음 100명만 자동 선정됩니다.
-                선정된 계정은 평생 경매 수수료 무료 혜택을 받고, 프로필에서 가장
-                강한 프레임과 뱃지를 받습니다.
-              </p>
-              <p className="mt-2 text-sm font-semibold text-orange-900">
-                {hasFoundingBreederCount
-                  ? isSoldOut
-                    ? "현재 100인 모집이 마감되었습니다."
-                    : `현재 ${foundingBreederCount}명 선정 · 잔여 ${remainingSlots}석`
-                  : "현재 창립 브리더 현황을 확인하는 중입니다."}
-              </p>
-            </section>
-
-            <section className="rounded-2xl border border-slate-200 p-4">
-              <p className="text-sm font-bold text-slate-900">다음 단계</p>
-              <p className="mt-2 text-sm leading-relaxed text-slate-700">
-                창립 브리더는 자동 100명, 파트너 브리더는 어드민 수동 설정, 인증
-                브리더는 추후 본인 인증 기능과 연결됩니다. 지금은 프로필과
-                로그인 흐름에서 먼저 노출하고, 이후 수수료 시스템이 생기면
-                혜택만 연결하면 됩니다.
-              </p>
-            </section>
           </div>
-        </article>
-      </div>
+        </section>
+
+        <section className="border-y border-slate-100 bg-slate-50 px-5 py-7">
+          <div className="flex items-end justify-between gap-4">
+            <div>
+              <p className="text-xs font-bold text-primary">혜택</p>
+              <h2 className="mt-2 text-xl font-extrabold tracking-normal text-slate-950">
+                프로필에서 바로 보이는 혜택
+              </h2>
+            </div>
+            <span className="text-xs font-semibold text-slate-400">3가지</span>
+          </div>
+
+          <ul className="mt-5 divide-y divide-slate-200 border-y border-slate-200">
+            {PROFILE_FEATURES.map((feature, index) => (
+              <li key={feature.title} className="flex gap-3 py-4">
+                <span className="mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-white text-xs font-black text-primary ring-1 ring-slate-200">
+                  {index + 1}
+                </span>
+                <div>
+                  <h3 className="text-sm font-bold tracking-normal text-slate-950">
+                    {feature.title}
+                  </h3>
+                  <p className="mt-1 text-sm font-medium leading-[1.55] tracking-normal text-slate-600">
+                    {feature.description}
+                  </p>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        <section className="bg-white px-5 py-7">
+          <p className="text-xs font-bold text-primary">멤버십</p>
+          <h2 className="mt-2 text-xl font-extrabold tracking-normal text-slate-950">
+            등급은 이렇게 나뉩니다
+          </h2>
+          <p className="mt-2 text-sm font-medium leading-[1.6] tracking-normal text-slate-500">
+            자동 선정, 운영팀 선정, 인증 기반 등급을 분리해 프로필 신뢰도를
+            단계적으로 보여줍니다.
+          </p>
+
+          <div className="mt-5 space-y-3">
+            {PROGRAM_TIERS.map((tier) => (
+              <section
+                key={tier.title}
+                className={`rounded-lg border p-4 ${tier.panelClassName}`}
+              >
+                <div className="flex items-start gap-3">
+                  <span
+                    className={`mt-1 h-2.5 w-2.5 shrink-0 rounded-sm ${tier.markerClassName}`}
+                  />
+                  <div className="min-w-0 flex-1">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <h3 className="text-base font-extrabold tracking-normal text-slate-950">
+                        {tier.title}
+                      </h3>
+                      <span
+                        className={`rounded-md px-2 py-1 text-[11px] font-bold ${tier.labelClassName}`}
+                      >
+                        {tier.label}
+                      </span>
+                    </div>
+                    <p className="mt-2 text-sm font-bold tracking-normal text-slate-800">
+                      {tier.benefit}
+                    </p>
+                    <p className="mt-1 text-sm font-medium leading-[1.55] tracking-normal text-slate-600">
+                      {tier.description}
+                    </p>
+                  </div>
+                </div>
+              </section>
+            ))}
+          </div>
+        </section>
+
+        <section className="bg-slate-950 px-5 py-7 text-white">
+          <p className="text-xs font-bold text-primary">창립 브리더 100</p>
+          <h2 className="mt-2 text-2xl font-extrabold leading-[1.25] tracking-normal">
+            처음 100명에게만
+            <br />
+            평생 수수료 0원
+          </h2>
+          <p className="mt-3 text-sm font-medium leading-[1.65] tracking-normal text-white/70">
+            출시 이후 새로 가입한 유저 중 처음 {FOUNDING_BREEDER_LIMIT}명만 자동
+            선정됩니다. 선정된 계정은 프로필에서 가장 강한 프레임과 배지를
+            받습니다.
+          </p>
+
+          <div className="mt-5 rounded-lg border border-white/10 bg-white/5 px-4 py-4">
+            <div className="flex items-center justify-between gap-3">
+              <span className="text-sm font-semibold text-white/65">
+                현재 상태
+              </span>
+              <span className="text-sm font-extrabold text-white">
+                {foundingStatusLabel}
+              </span>
+            </div>
+          </div>
+
+          <div className="mt-5 flex gap-2">
+            <Link
+              href="/auth/login"
+              className="inline-flex h-11 flex-1 items-center justify-center rounded-lg bg-white px-4 text-sm font-bold text-slate-950 transition hover:bg-slate-100"
+            >
+              지금 시작하기
+            </Link>
+            <Link
+              href="/support"
+              className="inline-flex h-11 items-center justify-center rounded-lg border border-white/20 px-4 text-sm font-bold text-white transition hover:bg-white/10"
+            >
+              문의
+            </Link>
+          </div>
+        </section>
+      </main>
     </Layout>
   );
 };

--- a/app/(web)/content/breeder-program/BreederProgramClient.tsx
+++ b/app/(web)/content/breeder-program/BreederProgramClient.tsx
@@ -11,8 +11,9 @@ const PROGRAM_CARDS = [
     summary: "출시 후 신규 가입 선착순 100명 자동 부여",
     badge: "평생 경매 수수료 무료",
     frame: "골드 프레임",
-    tone: "from-amber-50 via-white to-slate-50",
-    border: "border-amber-200",
+    panel: "border-orange-100 bg-orange-50/40",
+    kicker: "text-orange-700",
+    chip: "border-orange-100 bg-white text-orange-700",
     text: "창립 멤버만 받을 수 있는 가장 높은 프레스티지 자격입니다.",
   },
   {
@@ -20,8 +21,9 @@ const PROGRAM_CARDS = [
     summary: "DM 섭외나 외부 협의를 거쳐 어드민에서 수동 설정",
     badge: "협업 할인",
     frame: "프리미엄 프레임",
-    tone: "from-cyan-50 via-white to-slate-50",
-    border: "border-cyan-200",
+    panel: "border-blue-100 bg-blue-50/40",
+    kicker: "text-blue-700",
+    chip: "border-blue-100 bg-white text-blue-700",
     text: "브랜드/브리더 협업용 등급으로, 개별 할인율을 운영자가 지정합니다.",
   },
   {
@@ -29,8 +31,9 @@ const PROGRAM_CARDS = [
     summary: "나중에 본인 인증 플로우가 생기면 부여",
     badge: "신뢰 배지",
     frame: "실버 프레임",
-    tone: "from-slate-50 via-white to-white",
-    border: "border-slate-200",
+    panel: "border-slate-200 bg-slate-50",
+    kicker: "text-slate-600",
+    chip: "border-slate-200 bg-white text-slate-700",
     text: "본인 인증 기반의 신뢰 등급으로, 프로필 신뢰도를 올려줍니다.",
   },
 ];
@@ -52,31 +55,31 @@ const BreederProgramClient = ({
     <Layout canGoBack title="브리더 프로그램" seoTitle="브리더 프로그램">
       <div className="mx-auto max-w-3xl px-4 py-6">
         <article className="overflow-hidden rounded-3xl border border-slate-200 bg-white shadow-sm">
-          <div className="relative overflow-hidden bg-[radial-gradient(circle_at_top_left,_rgba(245,158,11,0.24),_transparent_34%),linear-gradient(135deg,#0f172a,#111827_56%,#1f2937)] px-5 py-6 text-white">
-            <p className="text-[11px] font-black uppercase tracking-[0.22em] text-amber-300">
+          <div className="relative overflow-hidden border-b border-slate-200 bg-slate-50 px-5 py-6 text-slate-950">
+            <p className="text-[11px] font-black uppercase tracking-[0.22em] text-slate-500">
               breeder program
             </p>
             <h1 className="mt-2 text-2xl font-black tracking-tight">
               브리디의 브리더 프레스티지 프로그램
             </h1>
-            <p className="mt-2 max-w-2xl text-sm leading-relaxed text-white/75">
+            <p className="mt-2 max-w-2xl text-sm leading-relaxed text-slate-600">
               창립 브리더 100인, 파트너 브리더, 인증 브리더를 각각 다른 방식으로
               운영합니다. 프로필에는 프레임과 배지를 더해 신뢰와 희소성을 함께
               보여줍니다.
             </p>
 
             <div className="mt-4 flex flex-wrap gap-2">
-              <span className="rounded-full bg-white/10 px-3 py-1 text-[11px] font-semibold text-white">
+              <span className="rounded-full border border-orange-100 bg-white px-3 py-1 text-[11px] font-semibold text-orange-700">
                 {hasFoundingBreederCount
                   ? isSoldOut
                     ? "창립 브리더 100인 마감"
                     : `창립 브리더 잔여 ${remainingSlots}석`
                   : "창립 브리더 현황 집계 중"}
               </span>
-              <span className="rounded-full bg-white/10 px-3 py-1 text-[11px] font-semibold text-white">
+              <span className="rounded-full border border-slate-200 bg-white px-3 py-1 text-[11px] font-semibold text-slate-700">
                 평생 경매 수수료 무료
               </span>
-              <span className="rounded-full bg-white/10 px-3 py-1 text-[11px] font-semibold text-white">
+              <span className="rounded-full border border-slate-200 bg-white px-3 py-1 text-[11px] font-semibold text-slate-700">
                 프로필 전용 프레임
               </span>
             </div>
@@ -84,13 +87,13 @@ const BreederProgramClient = ({
             <div className="mt-5 flex flex-wrap gap-3">
               <Link
                 href="/auth/login"
-                className="inline-flex h-10 items-center justify-center rounded-full bg-white px-4 text-sm font-semibold text-slate-900 transition hover:bg-slate-100"
+                className="inline-flex h-10 items-center justify-center rounded-full bg-slate-950 px-4 text-sm font-semibold text-white transition hover:bg-slate-800"
               >
                 로그인하러 가기
               </Link>
               <Link
                 href="/support"
-                className="inline-flex h-10 items-center justify-center rounded-full border border-white/20 px-4 text-sm font-semibold text-white transition hover:bg-white/10"
+                className="inline-flex h-10 items-center justify-center rounded-full border border-slate-300 bg-white px-4 text-sm font-semibold text-slate-700 transition hover:border-slate-400 hover:bg-slate-100"
               >
                 문의 남기기
               </Link>
@@ -105,7 +108,8 @@ const BreederProgramClient = ({
               <p className="mt-2 text-sm leading-relaxed text-slate-700">
                 브리더 자격이 있으면 프로필 사진에 전용 프레임이 붙고, 이름
                 아래에 전용 뱃지가 노출됩니다. 창립 브리더는 번호까지 표시해
-                희소성을 더하고, 파트너와 인증 브리더는 다른 색감으로 구분합니다.
+                희소성을 더하고, 파트너와 인증 브리더는 다른 색감으로
+                구분합니다.
               </p>
             </section>
 
@@ -113,9 +117,11 @@ const BreederProgramClient = ({
               {PROGRAM_CARDS.map((card) => (
                 <section
                   key={card.title}
-                  className={`rounded-2xl border ${card.border} bg-gradient-to-br ${card.tone} p-4 shadow-sm`}
+                  className={`rounded-2xl border ${card.panel} p-4`}
                 >
-                  <p className="text-xs font-black uppercase tracking-[0.18em] text-slate-500">
+                  <p
+                    className={`text-xs font-black uppercase tracking-[0.18em] ${card.kicker}`}
+                  >
                     {card.title}
                   </p>
                   <h3 className="mt-1 text-lg font-bold text-slate-900">
@@ -128,7 +134,9 @@ const BreederProgramClient = ({
                     {card.text}
                   </p>
                   <div className="mt-4 flex flex-wrap gap-2">
-                    <span className="rounded-full bg-white px-2.5 py-1 text-[11px] font-semibold text-slate-700 shadow-sm">
+                    <span
+                      className={`rounded-full border px-2.5 py-1 text-[11px] font-semibold ${card.chip}`}
+                    >
                       {card.frame}
                     </span>
                   </div>
@@ -136,16 +144,16 @@ const BreederProgramClient = ({
               ))}
             </div>
 
-            <section className="rounded-2xl border border-amber-200 bg-amber-50 p-4">
-              <p className="text-sm font-bold text-amber-900">
+            <section className="rounded-2xl border border-orange-100 bg-orange-50/50 p-4">
+              <p className="text-sm font-bold text-orange-900">
                 창립 브리더 100인
               </p>
-              <p className="mt-2 text-sm leading-relaxed text-amber-800">
+              <p className="mt-2 text-sm leading-relaxed text-orange-800">
                 출시 이후 새로 가입한 유저 중 처음 100명만 자동 선정됩니다.
                 선정된 계정은 평생 경매 수수료 무료 혜택을 받고, 프로필에서 가장
                 강한 프레임과 뱃지를 받습니다.
               </p>
-              <p className="mt-2 text-sm font-semibold text-amber-900">
+              <p className="mt-2 text-sm font-semibold text-orange-900">
                 {hasFoundingBreederCount
                   ? isSoldOut
                     ? "현재 100인 모집이 마감되었습니다."
@@ -158,9 +166,9 @@ const BreederProgramClient = ({
               <p className="text-sm font-bold text-slate-900">다음 단계</p>
               <p className="mt-2 text-sm leading-relaxed text-slate-700">
                 창립 브리더는 자동 100명, 파트너 브리더는 어드민 수동 설정, 인증
-                브리더는 추후 본인 인증 기능과 연결됩니다. 지금은 프로필과 로그인
-                흐름에서 먼저 노출하고, 이후 수수료 시스템이 생기면 혜택만
-                연결하면 됩니다.
+                브리더는 추후 본인 인증 기능과 연결됩니다. 지금은 프로필과
+                로그인 흐름에서 먼저 노출하고, 이후 수수료 시스템이 생기면
+                혜택만 연결하면 됩니다.
               </p>
             </section>
           </div>


### PR DESCRIPTION
### 개요
홈 상단 슬라이드를 더 심플한 카드형 배너로 정리하고, 바깥에 따로 보이던 페이지네이션 캡슐을 제거했습니다. 단일 배너에서는 슬라이드 네비를 숨기고, 다중 배너에서는 배너 안쪽 하단에 작은 검정 dot만 표시하도록 정리했습니다. 혈통카드 공유 챌린지 카드도 과한 그라데이션과 큰 둥근 pill 스타일을 제거해 흰 배경, 얇은 보더, 낮은 radius 중심의 뉴트럴 카드로 정리했습니다. 이번 주 TOP 브리더 섹션의 타이틀 위아래 간격도 살짝 늘려 홈 화면 흐름을 정리했습니다. 브리더 프로그램 화면은 요즘 한국 앱 랜딩페이지 톤으로 다시 구성했고, 혈통관리 상세/목록/이벤트 화면에는 공통 헤더와 바텀네비를 적용해 탐색 경험을 맞췄습니다.

### 변경 유형
- [ ] 버그 수정
- [ ] 새로운 기능 추가
- [x] 기존 기능 수정
- [x] 스타일 수정
- [ ] 기타(문서 수정, 리팩토링 등)

### 주요 변경사항
- 홈 상단 슬라이드를 좌우 여백이 있는 카드형 배너로 정리
- 홈 슬라이드 바깥 페이지네이션 캡슐 제거
- 홈 슬라이드가 1개일 때 네비 숨김 처리
- 홈 슬라이드가 2개 이상일 때 배너 내부 하단에 작은 검정 dot 네비 표시
- 홈 슬라이드 장식 요소를 덜어내고 제목/설명/CTA 위계를 단순화
- 혈통카드 공유 챌린지 카드를 뉴트럴 카드형 UI로 정리
- 혈통카드 공유 챌린지 카드의 radius를 8px 토큰 기준으로 낮추고 버튼 높이/간격 조정
- 이번 주 TOP 브리더 섹션 타이틀 상단/하단 간격 조정
- 브리더 프로그램 화면을 모바일 랜딩 구조로 재설계
- 브리더 프로그램 상단에 혜택 요약, 로그인 CTA, 프로필 미리보기 비주얼 추가
- 창립/파트너/인증 브리더 등급 설명을 앱형 리스트와 절제된 색상으로 정리
- 혈통관리 메인 목록 화면에 공통 헤더와 바텀네비 적용
- 혈통관리 섹션 목록/이벤트 목록 화면에 공통 헤더와 바텀네비 적용
- 혈통카드 상세 화면의 로딩/미존재/상세 상태에 공통 헤더와 바텀네비 적용

### 검증
- npm run verify:ci
- 인앱 브라우저에서 홈 슬라이드 모바일 폭 렌더링 확인
- 인앱 브라우저에서 단일 홈 슬라이드 네비 숨김 확인
- 인앱 브라우저에서 홈 슬라이드 바깥 페이지네이션 캡슐 제거 확인
- 인앱 브라우저에서 혈통카드 공유 챌린지 카드 모바일 폭 렌더링 확인
- 인앱 브라우저에서 혈통카드 공유 챌린지 카드 radius 8px, 가로 넘침 없음 확인
- 인앱 브라우저에서 이번 주 TOP 브리더 타이틀-카드 간격 12px 적용 확인
- 인앱 브라우저에서 홈 화면 가로 넘침 없음 확인
- 인앱 브라우저에서 /content/breeder-program 모바일 폭 렌더링 확인
- 인앱 브라우저에서 /content/breeder-program 가로 넘침 없음 확인
- 인앱 브라우저에서 혈통관리 목록/상세 화면 헤더·바텀네비 확인

### 참고
- 기존 lint warning: app/(web)/bloodline-cards/create/BloodlineCardCreateClient.tsx의 <img> 사용 경고 1건은 이번 변경 전부터 존재했습니다.
- .omc/ 미추적 파일은 건드리지 않았습니다.
- GitHub push 응답에서 기본 브랜치의 기존 Dependabot 취약점 안내가 출력되었습니다.

### 관련 태스크 / 이슈
- 없음

### 스크린샷
- 로컬 인앱 브라우저에서 확인 완료