### PR TITLE
테스트 계정 전환 진입점 복구

### DIFF
--- a/__tests__/testAccounts.test.ts
+++ b/__tests__/testAccounts.test.ts
@@ -1,0 +1,27 @@
+import {
+  canUseTestAccountSwitcher,
+  isProductionLikeEnv,
+  isTestAccountUser,
+  shouldShowTestLoginForEnv,
+} from "@libs/shared/test-accounts";
+
+describe("test account helpers", () => {
+  it("운영 환경에서는 기본 로그인 화면의 테스트 로그인 섹션을 숨긴다", () => {
+    expect(shouldShowTestLoginForEnv("production")).toBe(false);
+    expect(shouldShowTestLoginForEnv("prod")).toBe(false);
+    expect(shouldShowTestLoginForEnv("preview")).toBe(true);
+    expect(isProductionLikeEnv("development")).toBe(false);
+  });
+
+  it("FAKE_USER 또는 test_user 계정을 테스트 계정으로 판단한다", () => {
+    expect(isTestAccountUser({ role: "FAKE_USER", provider: "kakao" })).toBe(true);
+    expect(isTestAccountUser({ role: "USER", provider: "test_user" })).toBe(true);
+    expect(isTestAccountUser({ role: "USER", provider: "kakao" })).toBe(false);
+  });
+
+  it("테스트 계정 전환 목록은 FAKE_USER와 관리자에게 노출한다", () => {
+    expect(canUseTestAccountSwitcher({ role: "USER", provider: "kakao" }, true)).toBe(true);
+    expect(canUseTestAccountSwitcher({ role: "FAKE_USER", provider: "test_user" }, false)).toBe(true);
+    expect(canUseTestAccountSwitcher({ role: "USER", provider: "kakao" }, false)).toBe(false);
+  });
+});

--- a/app/(web)/myPage/MyPageClient.tsx
+++ b/app/(web)/myPage/MyPageClient.tsx
@@ -2,6 +2,10 @@
 
 import { authFetch } from "@libs/client/authFetch";
 import { setTokens } from "@libs/client/authToken";
+import {
+  canUseTestAccountSwitcher,
+  isTestAccountUser,
+} from "@libs/shared/test-accounts";
 import Image from "@components/atoms/Image";
 import { Spinner } from "@components/atoms/Spinner";
 import MyCommentList from "@components/features/profile/MyCommentList";
@@ -75,18 +79,6 @@ type TestAccountSwitchResponse = {
   accessToken?: string;
   refreshToken?: string;
   expiresIn?: number;
-};
-
-const isTestEnvAvailable = () => {
-  const rawEnv = String(
-    process.env.NEXT_PUBLIC_VERCEL_ENV ||
-      process.env.VERCEL_ENV ||
-      process.env.NEXT_PUBLIC_APP_ENV ||
-      process.env.APP_ENV ||
-      process.env.NODE_ENV ||
-      "development"
-  ).toLowerCase();
-  return rawEnv !== "production" && rawEnv !== "prod";
 };
 
 const GuinnessSubmissionList = ({
@@ -238,12 +230,12 @@ const MyPageClient = () => {
     );
   }, [bloodlineData, user?.id]);
 
-  const isTestEnv = isTestEnvAvailable();
-  const isTestUser = user?.role === "FAKE_USER" || user?.provider === "test_user";
+  const isTestUser = isTestAccountUser(user);
+  const canSwitchTestAccount = canUseTestAccountSwitcher(user, Boolean(isAdmin));
   const fakeUserListForSwitch = fakeUsers.filter((item) => item.id !== user?.id);
 
   useEffect(() => {
-    if (!isTestEnv || !isTestUser) return;
+    if (!canSwitchTestAccount) return;
 
     let mounted = true;
     setFakeUsersLoading(true);
@@ -284,7 +276,7 @@ const MyPageClient = () => {
     return () => {
       mounted = false;
     };
-  }, [isTestUser, isTestEnv]);
+  }, [canSwitchTestAccount]);
 
   const tabCountMap: Record<ActivityTab, number> = {
     posts: profileUser?._count?.posts ?? 0,
@@ -491,7 +483,7 @@ const MyPageClient = () => {
             로그아웃
           </Button>
         </div>
-        {isTestUser ? (
+        {canSwitchTestAccount ? (
           <div className="mt-4 rounded-lg border border-slate-200 bg-slate-50 p-3 dark:border-slate-700/80 dark:bg-slate-800/50">
             <p className="text-xs font-semibold text-slate-700">다른 FAKE_USER 전환</p>
             <p className="mt-1 text-[11px] text-slate-500">

--- a/app/auth/login/fake/page.tsx
+++ b/app/auth/login/fake/page.tsx
@@ -1,0 +1,7 @@
+import LoginClient from "../LoginClient";
+
+const Page = () => {
+  return <LoginClient shouldShowTestLogin={true} />;
+};
+
+export default Page;

--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -1,15 +1,15 @@
 import LoginClient from "./LoginClient";
+import { shouldShowTestLoginForEnv } from "@libs/shared/test-accounts";
 
 const shouldDisplayTestLogin = (() => {
-  const runtimeEnv = String(
+  const runtimeEnv =
     process.env.NEXT_PUBLIC_VERCEL_ENV ||
-      process.env.VERCEL_ENV ||
-      process.env.NEXT_PUBLIC_APP_ENV ||
-      process.env.NODE_ENV ||
-      "development"
-  ).toLowerCase();
+    process.env.VERCEL_ENV ||
+    process.env.NEXT_PUBLIC_APP_ENV ||
+    process.env.NODE_ENV ||
+    "development";
 
-  return runtimeEnv !== "production" && runtimeEnv !== "prod";
+  return shouldShowTestLoginForEnv(runtimeEnv);
 })();
 
 const Page = async () => {

--- a/libs/shared/test-accounts.ts
+++ b/libs/shared/test-accounts.ts
@@ -1,0 +1,24 @@
+export type TestAccountViewer = {
+  role?: string | null;
+  provider?: string | null;
+};
+
+export const isProductionLikeEnv = (rawEnv?: string | null) => {
+  const normalized = String(rawEnv || "development").toLowerCase();
+  return normalized === "production" || normalized === "prod";
+};
+
+export const isTestAccountUser = (user?: TestAccountViewer | null) => {
+  return user?.role === "FAKE_USER" || user?.provider === "test_user";
+};
+
+export const canUseTestAccountSwitcher = (
+  user: TestAccountViewer | null | undefined,
+  isAdmin: boolean
+) => {
+  return Boolean(isAdmin || isTestAccountUser(user));
+};
+
+export const shouldShowTestLoginForEnv = (rawEnv?: string | null) => {
+  return !isProductionLikeEnv(rawEnv);
+};

--- a/proxy.ts
+++ b/proxy.ts
@@ -4,6 +4,10 @@ const TOOL_MODE_COOKIE = "bredy_tool_mode";
 
 export function proxy(req: NextRequest, ev: NextFetchEvent) {
   const { pathname, search } = req.nextUrl;
+  if (pathname === "/myPage/fake") {
+    return NextResponse.redirect(new URL("/fake", req.url));
+  }
+
   if (pathname.startsWith("/products/")) {
     console.info("[middleware][products]", {
       pathname,


### PR DESCRIPTION
### 개요

테스트 계정 목록 API와 /fake 화면은 살아있지만, 기존에 사용하던 /auth/login/fake, /myPage/fake 진입점이 404로 보이거나 운영 계정 마이페이지에서 전환 목록이 숨겨지는 문제가 있었습니다.

이 PR은 테스트 계정 전환 진입점을 복구하고, 관리자 또는 FAKE_USER 계정에서 전환 목록을 안정적으로 볼 수 있도록 조건을 정리합니다.

### 변경 유형

- [x] 버그 수정
- [ ] 새로운 기능 추가
- [x] 기존 기능 수정
- [ ] 스타일 수정
- [ ] 기타(문서 수정, 리팩토링 등)

### 주요 변경사항

- /auth/login/fake 라우트에서 테스트 로그인 목록을 강제로 노출하도록 추가
- /myPage/fake 접근 시 /fake로 리다이렉트하도록 proxy 처리
- 테스트 계정 판별/노출 조건을 libs/shared/test-accounts.ts로 분리
- 마이페이지 FAKE_USER 전환 목록을 FAKE_USER 또는 관리자 계정에서 노출하도록 변경
- 테스트 계정 조건 회귀 테스트 추가

---

### 관련 태스크 / 이슈

- 없음

### 테스트

- [x] npm run verify:ci
- [x] 로컬 브라우저 확인: /auth/login/fake 테스트 로그인 목록 노출
- [x] 로컬 브라우저 확인: /myPage/fake -> /fake 리다이렉트 후 FAKE_USER 목록 노출

### 참고

- lint는 통과했으며 기존 warning 3건은 유지됩니다.
  - app/(web)/bloodline-cards/create/BloodlineCardCreateClient.tsx: no-img-element
  - components/auth/AuthGuard.tsx: unused eslint-disable 2건

### 스크린샷

- 별도 첨부 없음